### PR TITLE
Fix typing of trigger to include `args`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1243,7 +1243,7 @@ declare namespace grapesjs {
      * @param event - Event to trigger
      * @param args - payload to send along with the event
      */
-    trigger(event: EditorEvent, ...args: any[]): Editor;
+    trigger(event: GrapesEvent, ...args: any[]): Editor;
     /**
      * Destroy the editor
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1241,8 +1241,9 @@ declare namespace grapesjs {
     /**
      * Trigger event
      * @param event - Event to trigger
+     * @param args - payload to send along with the event
      */
-    trigger(event: GrapesEvent): Editor;
+    trigger(event: EditorEvent, ...args: any[]): Editor;
     /**
      * Destroy the editor
      */


### PR DESCRIPTION
Hello, I noticed that the typing for `editor.trigger` did not match between [`editor/index.ts`](https://github.com/GrapesJS/grapesjs/blob/a83847b1b35e69e5a5810ccf1eb1e1384bf0aab1/src/editor/index.ts#L761-L769) and the root `index.d.ts`, so I updated the `index.d.ts` to include the `args` param.