### PR TITLE
Fix broken links in the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,14 +39,14 @@ Before submitting an expense contact core contributors via the current active ch
 
 ## Questions
 
-If you have any questions, create an [issue](https://github.com/artf/grapesjs/issues) (protip: do a quick search first to see if someone else didn't ask the same question before!).
+If you have any questions, create an [issue](https://github.com/GrapesJS/grapesjs/issues) (protip: do a quick search first to see if someone else didn't ask the same question before!).
 
 
 
 ## Credits
 
 Thank you to all the people who have already contributed to GrapesJS!
-<a href="/artf/grapesjs/graphs/contributors"><img src="https://opencollective.com/grapesjs/contributors.svg?width=890" /></a>
+<a href="/GrapesJS/grapesjs/graphs/contributors"><img src="https://opencollective.com/grapesjs/contributors.svg?width=890" /></a>
 
 
 [Open Collective]: <https://opencollective.com/grapesjs>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [GrapesJS](http://grapesjs.com)
 
-[![Build Status](https://github.com/artf/grapesjs/actions/workflows/build.yml/badge.svg)](https://github.com/artf/grapesjs/actions)
+[![Build Status](https://github.com/GrapesJS/grapesjs/actions/workflows/build.yml/badge.svg)](https://github.com/GrapesJS/grapesjs/actions)
 [![Chat](https://img.shields.io/badge/chat-discord-7289da.svg)](https://discord.gg/QAbgGXq)
 [![CDNJS](https://img.shields.io/cdnjs/v/grapesjs.svg)](https://cdnjs.com/libraries/grapesjs)
 [![npm](https://img.shields.io/npm/v/grapesjs.svg)](https://www.npmjs.com/package/grapesjs)
@@ -36,8 +36,8 @@ Newsletter Demo - http://grapesjs.com/demo-newsletter-editor.html<br/>
 * [Testing](#testing)
 * [Plugins](#plugins)
 * [Support](#support)
-* [Changelog](https://github.com/artf/grapesjs/releases)
-* [Contributing](https://github.com/artf/grapesjs/blob/master/CONTRIBUTING.md)
+* [Changelog](https://github.com/GrapesJS/grapesjs/releases)
+* [Contributing](https://github.com/GrapesJS/grapesjs/blob/master/CONTRIBUTING.md)
 * [License](#license)
 
 
@@ -73,7 +73,7 @@ Newsletter Demo - http://grapesjs.com/demo-newsletter-editor.html<br/>
 * NPM
   * `npm i grapesjs`
 * GIT
-  * `git clone https://github.com/artf/grapesjs.git`
+  * `git clone https://github.com/GrapesJS/grapesjs.git`
 
 For the development purpose you should follow instructions below.
 
@@ -106,7 +106,7 @@ For a more practical example I'd suggest looking up the code inside this demo: h
 Clone the repository and install all the necessary dependencies (`yarn` is highly recommended)
 
 ```sh
-$ git clone https://github.com/artf/grapesjs.git
+$ git clone https://github.com/GrapesJS/grapesjs.git
 $ cd grapesjs
 $ yarn
 ```
@@ -152,36 +152,36 @@ $ yarn test
 ## Plugins
 
 ### Extensions
-* [grapesjs-plugin-export](https://github.com/artf/grapesjs-plugin-export) - Export GrapesJS templates in a zip archive
-* [grapesjs-plugin-filestack](https://github.com/artf/grapesjs-plugin-filestack) - Add Filestack uploader in Asset Manager
-* [grapesjs-plugin-ckeditor](https://github.com/artf/grapesjs-plugin-ckeditor) - Replaces the built-in RTE with CKEditor
-* [grapesjs-aviary](https://github.com/artf/grapesjs-aviary) - Add the Aviary Image Editor (dismissed, use the plugin below instead)
-* [grapesjs-tui-image-editor](https://github.com/artf/grapesjs-tui-image-editor) - GrapesJS TOAST UI Image Editor
-* [grapesjs-blocks-basic](https://github.com/artf/grapesjs-blocks-basic) - Basic set of blocks
-* [grapesjs-plugin-forms](https://github.com/artf/grapesjs-plugin-forms) - Set of form components and blocks
-* [grapesjs-navbar](https://github.com/artf/grapesjs-navbar) - Simple navbar component
-* [grapesjs-component-countdown](https://github.com/artf/grapesjs-component-countdown) - Simple countdown component
-* [grapesjs-style-gradient](https://github.com/artf/grapesjs-style-gradient) - Add `gradient` type input to the Style Manager
-* [grapesjs-style-filter](https://github.com/artf/grapesjs-style-filter) - Add `filter` type input to the Style Manager
-* [grapesjs-style-bg](https://github.com/artf/grapesjs-style-bg) - Full-stack background style property type, with the possibility to add images, colors, and gradients
-* [grapesjs-blocks-flexbox](https://github.com/artf/grapesjs-blocks-flexbox) - Add the flexbox block
-* [grapesjs-lory-slider](https://github.com/artf/grapesjs-lory-slider) - Slider component by using [lory](https://github.com/meandmax/lory)
-* [grapesjs-tabs](https://github.com/artf/grapesjs-tabs) - Simple tabs component
-* [grapesjs-tooltip](https://github.com/artf/grapesjs-tooltip) - Simple, CSS only, tooltip component for GrapesJS
-* [grapesjs-custom-code](https://github.com/artf/grapesjs-custom-code) - Embed custom code
-* [grapesjs-touch](https://github.com/artf/grapesjs-touch) - Enable touch support
-* [grapesjs-indexeddb](https://github.com/artf/grapesjs-indexeddb) - Storage wrapper for IndexedDB
-* [grapesjs-firestore](https://github.com/artf/grapesjs-firestore) - Storage wrapper for [Cloud Firestore](https://firebase.google.com/docs/firestore)
-* [grapesjs-parser-postcss](https://github.com/artf/grapesjs-parser-postcss) - Custom CSS parser for GrapesJS by using [PostCSS](https://github.com/postcss/postcss)
-* [grapesjs-typed](https://github.com/artf/grapesjs-typed) - Typed component made by wrapping Typed.js library
+* [grapesjs-plugin-export](https://github.com/GrapesJS/grapesjs-plugin-export) - Export GrapesJS templates in a zip archive
+* [grapesjs-plugin-filestack](https://github.com/GrapesJS/grapesjs-plugin-filestack) - Add Filestack uploader in Asset Manager
+* [grapesjs-plugin-ckeditor](https://github.com/GrapesJS/grapesjs-plugin-ckeditor) - Replaces the built-in RTE with CKEditor
+* [grapesjs-aviary](https://github.com/GrapesJS/grapesjs-aviary) - Add the Aviary Image Editor (dismissed, use the plugin below instead)
+* [grapesjs-tui-image-editor](https://github.com/GrapesJS/grapesjs-tui-image-editor) - GrapesJS TOAST UI Image Editor
+* [grapesjs-blocks-basic](https://github.com/GrapesJS/grapesjs-blocks-basic) - Basic set of blocks
+* [grapesjs-plugin-forms](https://github.com/GrapesJS/grapesjs-plugin-forms) - Set of form components and blocks
+* [grapesjs-navbar](https://github.com/GrapesJS/grapesjs-navbar) - Simple navbar component
+* [grapesjs-component-countdown](https://github.com/GrapesJS/grapesjs-component-countdown) - Simple countdown component
+* [grapesjs-style-gradient](https://github.com/GrapesJS/grapesjs-style-gradient) - Add `gradient` type input to the Style Manager
+* [grapesjs-style-filter](https://github.com/GrapesJS/grapesjs-style-filter) - Add `filter` type input to the Style Manager
+* [grapesjs-style-bg](https://github.com/GrapesJS/grapesjs-style-bg) - Full-stack background style property type, with the possibility to add images, colors, and gradients
+* [grapesjs-blocks-flexbox](https://github.com/GrapesJS/grapesjs-blocks-flexbox) - Add the flexbox block
+* [grapesjs-lory-slider](https://github.com/GrapesJS/grapesjs-lory-slider) - Slider component by using [lory](https://github.com/meandmax/lory)
+* [grapesjs-tabs](https://github.com/GrapesJS/grapesjs-tabs) - Simple tabs component
+* [grapesjs-tooltip](https://github.com/GrapesJS/grapesjs-tooltip) - Simple, CSS only, tooltip component for GrapesJS
+* [grapesjs-custom-code](https://github.com/GrapesJS/grapesjs-custom-code) - Embed custom code
+* [grapesjs-touch](https://github.com/GrapesJS/grapesjs-touch) - Enable touch support
+* [grapesjs-indexeddb](https://github.com/GrapesJS/grapesjs-indexeddb) - Storage wrapper for IndexedDB
+* [grapesjs-firestore](https://github.com/GrapesJS/grapesjs-firestore) - Storage wrapper for [Cloud Firestore](https://firebase.google.com/docs/firestore)
+* [grapesjs-parser-postcss](https://github.com/GrapesJS/grapesjs-parser-postcss) - Custom CSS parser for GrapesJS by using [PostCSS](https://github.com/postcss/postcss)
+* [grapesjs-typed](https://github.com/GrapesJS/grapesjs-typed) - Typed component made by wrapping Typed.js library
 * [grapesjs-ui-suggest-classes](https://github.com/silexlabs/grapesjs-ui-suggest-classes) - Enable auto-complete of classes in the SelectorManager UI
 * [grapesjs-fonts](https://github.com/silexlabs/grapesjs-fonts) - Custom Fonts plugin, adds a UI to manage fonts in websites
 * [grapesjs-symbols](https://github.com/silexlabs/grapesjs-symbols) - Symbols plugin to reuse elements in a website and accross pages
 
 ### Presets
-* [grapesjs-preset-webpage](https://github.com/artf/grapesjs-preset-webpage) - Webpage Builder
-* [grapesjs-preset-newsletter](https://github.com/artf/grapesjs-preset-newsletter) - Newsletter Builder
-* [grapesjs-mjml](https://github.com/artf/grapesjs-mjml) - Newsletter Builder with MJML components
+* [grapesjs-preset-webpage](https://github.com/GrapesJS/grapesjs-preset-webpage) - Webpage Builder
+* [grapesjs-preset-newsletter](https://github.com/GrapesJS/grapesjs-preset-newsletter) - Newsletter Builder
+* [grapesjs-mjml](https://github.com/GrapesJS/grapesjs-mjml) - Newsletter Builder with MJML components
 
 
 Find out more about plugins here: [Creating plugins](https://grapesjs.com/docs/modules/Plugins.html)

--- a/README.md
+++ b/README.md
@@ -152,36 +152,36 @@ $ yarn test
 ## Plugins
 
 ### Extensions
-* [grapesjs-plugin-export](https://github.com/GrapesJS/grapesjs-plugin-export) - Export GrapesJS templates in a zip archive
-* [grapesjs-plugin-filestack](https://github.com/GrapesJS/grapesjs-plugin-filestack) - Add Filestack uploader in Asset Manager
-* [grapesjs-plugin-ckeditor](https://github.com/GrapesJS/grapesjs-plugin-ckeditor) - Replaces the built-in RTE with CKEditor
-* [grapesjs-aviary](https://github.com/GrapesJS/grapesjs-aviary) - Add the Aviary Image Editor (dismissed, use the plugin below instead)
-* [grapesjs-tui-image-editor](https://github.com/GrapesJS/grapesjs-tui-image-editor) - GrapesJS TOAST UI Image Editor
-* [grapesjs-blocks-basic](https://github.com/GrapesJS/grapesjs-blocks-basic) - Basic set of blocks
-* [grapesjs-plugin-forms](https://github.com/GrapesJS/grapesjs-plugin-forms) - Set of form components and blocks
-* [grapesjs-navbar](https://github.com/GrapesJS/grapesjs-navbar) - Simple navbar component
-* [grapesjs-component-countdown](https://github.com/GrapesJS/grapesjs-component-countdown) - Simple countdown component
-* [grapesjs-style-gradient](https://github.com/GrapesJS/grapesjs-style-gradient) - Add `gradient` type input to the Style Manager
-* [grapesjs-style-filter](https://github.com/GrapesJS/grapesjs-style-filter) - Add `filter` type input to the Style Manager
-* [grapesjs-style-bg](https://github.com/GrapesJS/grapesjs-style-bg) - Full-stack background style property type, with the possibility to add images, colors, and gradients
-* [grapesjs-blocks-flexbox](https://github.com/GrapesJS/grapesjs-blocks-flexbox) - Add the flexbox block
-* [grapesjs-lory-slider](https://github.com/GrapesJS/grapesjs-lory-slider) - Slider component by using [lory](https://github.com/meandmax/lory)
-* [grapesjs-tabs](https://github.com/GrapesJS/grapesjs-tabs) - Simple tabs component
-* [grapesjs-tooltip](https://github.com/GrapesJS/grapesjs-tooltip) - Simple, CSS only, tooltip component for GrapesJS
-* [grapesjs-custom-code](https://github.com/GrapesJS/grapesjs-custom-code) - Embed custom code
-* [grapesjs-touch](https://github.com/GrapesJS/grapesjs-touch) - Enable touch support
-* [grapesjs-indexeddb](https://github.com/GrapesJS/grapesjs-indexeddb) - Storage wrapper for IndexedDB
-* [grapesjs-firestore](https://github.com/GrapesJS/grapesjs-firestore) - Storage wrapper for [Cloud Firestore](https://firebase.google.com/docs/firestore)
-* [grapesjs-parser-postcss](https://github.com/GrapesJS/grapesjs-parser-postcss) - Custom CSS parser for GrapesJS by using [PostCSS](https://github.com/postcss/postcss)
-* [grapesjs-typed](https://github.com/GrapesJS/grapesjs-typed) - Typed component made by wrapping Typed.js library
+* [grapesjs-plugin-export](https://github.com/GrapesJS/export) - Export GrapesJS templates in a zip archive
+* [grapesjs-plugin-filestack](https://github.com/GrapesJS/filestack) - Add Filestack uploader in Asset Manager
+* [grapesjs-plugin-ckeditor](https://github.com/GrapesJS/ckeditor) - Replaces the built-in RTE with CKEditor
+* [grapesjs-aviary](https://github.com/GrapesJS/aviary) - Add the Aviary Image Editor (dismissed, use the plugin below instead)
+* [grapesjs-tui-image-editor](https://github.com/GrapesJS/tui-image-editor) - GrapesJS TOAST UI Image Editor
+* [grapesjs-blocks-basic](https://github.com/GrapesJS/blocks-basic) - Basic set of blocks
+* [grapesjs-plugin-forms](https://github.com/GrapesJS/forms) - Set of form components and blocks
+* [grapesjs-navbar](https://github.com/GrapesJS/navbar) - Simple navbar component
+* [grapesjs-component-countdown](https://github.com/GrapesJS/component-countdown) - Simple countdown component
+* [grapesjs-style-gradient](https://github.com/GrapesJS/style-gradient) - Add `gradient` type input to the Style Manager
+* [grapesjs-style-filter](https://github.com/GrapesJS/style-filter) - Add `filter` type input to the Style Manager
+* [grapesjs-style-bg](https://github.com/GrapesJS/style-bg) - Full-stack background style property type, with the possibility to add images, colors, and gradients
+* [grapesjs-blocks-flexbox](https://github.com/GrapesJS/blocks-flexbox) - Add the flexbox block
+* [grapesjs-lory-slider](https://github.com/GrapesJS/lory-slider) - Slider component by using [lory](https://github.com/meandmax/lory)
+* [grapesjs-tabs](https://github.com/GrapesJS/tabs) - Simple tabs component
+* [grapesjs-tooltip](https://github.com/GrapesJS/tooltip) - Simple, CSS only, tooltip component for GrapesJS
+* [grapesjs-custom-code](https://github.com/GrapesJS/custom-code) - Embed custom code
+* [grapesjs-touch](https://github.com/GrapesJS/touch) - Enable touch support
+* [grapesjs-indexeddb](https://github.com/GrapesJS/indexeddb) - Storage wrapper for IndexedDB
+* [grapesjs-firestore](https://github.com/GrapesJS/firestore) - Storage wrapper for [Cloud Firestore](https://firebase.google.com/docs/firestore)
+* [grapesjs-parser-postcss](https://github.com/GrapesJS/parser-postcss) - Custom CSS parser for GrapesJS by using [PostCSS](https://github.com/postcss/postcss)
+* [grapesjs-typed](https://github.com/GrapesJS/typed) - Typed component made by wrapping Typed.js library
 * [grapesjs-ui-suggest-classes](https://github.com/silexlabs/grapesjs-ui-suggest-classes) - Enable auto-complete of classes in the SelectorManager UI
 * [grapesjs-fonts](https://github.com/silexlabs/grapesjs-fonts) - Custom Fonts plugin, adds a UI to manage fonts in websites
 * [grapesjs-symbols](https://github.com/silexlabs/grapesjs-symbols) - Symbols plugin to reuse elements in a website and accross pages
 
 ### Presets
-* [grapesjs-preset-webpage](https://github.com/GrapesJS/grapesjs-preset-webpage) - Webpage Builder
-* [grapesjs-preset-newsletter](https://github.com/GrapesJS/grapesjs-preset-newsletter) - Newsletter Builder
-* [grapesjs-mjml](https://github.com/GrapesJS/grapesjs-mjml) - Newsletter Builder with MJML components
+* [grapesjs-preset-webpage](https://github.com/GrapesJS/preset-webpage) - Webpage Builder
+* [grapesjs-preset-newsletter](https://github.com/GrapesJS/preset-newsletter) - Newsletter Builder
+* [grapesjs-mjml](https://github.com/GrapesJS/mjml) - Newsletter Builder with MJML components
 
 
 Find out more about plugins here: [Creating plugins](https://grapesjs.com/docs/modules/Plugins.html)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,9 @@ GrapesJS was designed  primarily for use inside Content Management Systems to sp
 ## Quick Start
 To showcase the power of GrapesJS we have created some presets.
 
-* [grapesjs-preset-webpage](https://github.com/GrapesJS/grapesjs-preset-webpage) - [Webpage Builder](https://grapesjs.com/demo.html)
-* [grapesjs-preset-newsletter](https://github.com/GrapesJS/grapesjs-preset-newsletter) - [Newsletter Builder](https://grapesjs.com/demo-newsletter-editor.html)
-* [grapesjs-mjml](https://github.com/GrapesJS/grapesjs-mjml) - [Newsletter Builder with MJML](https://grapesjs/demo-mjml.html)
+* [grapesjs-preset-webpage](https://github.com/GrapesJS/preset-webpage) - [Webpage Builder](https://grapesjs.com/demo.html)
+* [grapesjs-preset-newsletter](https://github.com/GrapesJS/preset-newsletter) - [Newsletter Builder](https://grapesjs.com/demo-newsletter-editor.html)
+* [grapesjs-mjml](https://github.com/GrapesJS/mjml) - [Newsletter Builder with MJML](https://grapesjs/demo-mjml.html)
 
 You can actually use them as a starting point for your editors, so, just follow the instructions on their repositories to get a quick start for your builder.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,9 @@ GrapesJS was designed  primarily for use inside Content Management Systems to sp
 ## Quick Start
 To showcase the power of GrapesJS we have created some presets.
 
-* [grapesjs-preset-webpage](https://github.com/artf/grapesjs-preset-webpage) - [Webpage Builder](http://artf.github.io/grapesjs/demo.html)
-* [grapesjs-preset-newsletter](https://github.com/artf/grapesjs-preset-newsletter) - [Newsletter Builder](http://artf.github.io/grapesjs/demo-newsletter-editor.html)
-* [grapesjs-mjml](https://github.com/artf/grapesjs-mjml) - [Newsletter Builder with MJML](http://artf.github.io/grapesjs/demo-mjml.html)
+* [grapesjs-preset-webpage](https://github.com/GrapesJS/grapesjs-preset-webpage) - [Webpage Builder](https://grapesjs.com/demo.html)
+* [grapesjs-preset-newsletter](https://github.com/GrapesJS/grapesjs-preset-newsletter) - [Newsletter Builder](https://grapesjs.com/demo-newsletter-editor.html)
+* [grapesjs-mjml](https://github.com/GrapesJS/grapesjs-mjml) - [Newsletter Builder with MJML](https://grapesjs/demo-mjml.html)
 
 You can actually use them as a starting point for your editors, so, just follow the instructions on their repositories to get a quick start for your builder.
 
@@ -46,12 +46,12 @@ You can download GrapesJS from one of these sources
 * npm
   * `npm i grapesjs`
 * git
-  * `git clone https://github.com/artf/grapesjs.git`
+  * `git clone https://github.com/GrapesJS/grapesjs.git`
 
 
 
 
 ## Changelog
 
-To track changes made in the library we rely on [Github Releases](https://github.com/artf/grapesjs/releases)
+To track changes made in the library we rely on [Github Releases](https://github.com/GrapesJS/grapesjs/releases)
 

--- a/docs/api/assets.md
+++ b/docs/api/assets.md
@@ -179,7 +179,7 @@ Return the Asset Manager Container
 
 Returns **[HTMLElement][16]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/asset_manager/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.ts
 
 [2]: #open
 

--- a/docs/api/block_manager.md
+++ b/docs/api/block_manager.md
@@ -189,7 +189,7 @@ document.getElementById('some-id').appendChild(newBlocksEl);
 
 Returns **[HTMLElement][14]** Rendered element
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/block_manager/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.ts
 
 [2]: #add
 

--- a/docs/api/canvas.md
+++ b/docs/api/canvas.md
@@ -233,7 +233,7 @@ canvas.addFrame({
 
 Returns **[Frame]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/canvas/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/canvas/config/config.ts
 
 [2]: #getconfig
 

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -197,7 +197,7 @@ console.log(commands.getActive());
 
 Returns **[Object][12]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/commands/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/commands/config/config.ts
 
 [2]: #add
 

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -113,7 +113,7 @@ Returns **[Number][9]**
 ## setDragMode
 
 Change the drag mode of the component.
-To get more about this feature read: [https://github.com/artf/grapesjs/issues/1936][10]
+To get more about this feature read: [https://github.com/GrapesJS/grapesjs/issues/1936][10]
 
 ### Parameters
 
@@ -829,7 +829,7 @@ Returns **[Boolean][3]**
 
 [5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[6]: https://github.com/artf/grapesjs/blob/master/src/utils/Resizer.js
+[6]: https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.js
 
 [7]: /modules/Components-js.html
 
@@ -837,6 +837,6 @@ Returns **[Boolean][3]**
 
 [9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[10]: https://github.com/artf/grapesjs/issues/1936
+[10]: https://github.com/GrapesJS/grapesjs/issues/1936
 
 [11]: https://developer.mozilla.org/docs/Web/HTML/Element

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -200,7 +200,7 @@ Return the array of all types
 
 Returns **[Array][11]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/dom_components/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/dom_components/config/config.ts
 
 [2]: #getwrapper
 

--- a/docs/api/css_composer.md
+++ b/docs/api/css_composer.md
@@ -155,7 +155,7 @@ Remove all rules
 
 Returns **this** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/css_composer/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/css_composer/config/config.ts
 
 [2]: #addrules
 

--- a/docs/api/device_manager.md
+++ b/docs/api/device_manager.md
@@ -148,7 +148,7 @@ const selected = deviceManager.getSelected();
 
 Returns **[Device]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/device_manager/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/device_manager/config/config.ts
 
 [2]: #add
 

--- a/docs/api/editor.md
+++ b/docs/api/editor.md
@@ -575,7 +575,7 @@ Returns **this**
 ## setDragMode
 
 Change the global drag mode of components.
-To get more about this feature read: [https://github.com/artf/grapesjs/issues/1936][24]
+To get more about this feature read: [https://github.com/GrapesJS/grapesjs/issues/1936][24]
 
 ### Parameters
 
@@ -725,7 +725,7 @@ const strHtml = editor.html`Escaped ${unsafeStr} unescaped $${safeStr}`;
 
 Returns **[String][18]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/editor/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/editor/config/config.ts
 
 [2]: /api/components.html
 
@@ -771,4 +771,4 @@ Returns **[String][18]**
 
 [23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[24]: https://github.com/artf/grapesjs/issues/1936
+[24]: https://github.com/GrapesJS/grapesjs/issues/1936

--- a/docs/api/i18n.md
+++ b/docs/api/i18n.md
@@ -150,7 +150,7 @@ Get configuration object
 
 Returns **[Object][3]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/i18n/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/i18n/config.ts
 
 [2]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 

--- a/docs/api/modal_dialog.md
+++ b/docs/api/modal_dialog.md
@@ -188,7 +188,7 @@ modal.getContent();
 
 Returns **([string][12] | [HTMLElement][13])** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/modal_dialog/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/modal_dialog/config/config.ts
 
 [2]: #open
 

--- a/docs/api/panels.md
+++ b/docs/api/panels.md
@@ -179,7 +179,7 @@ var button = panelManager.getButton('myPanel','myButton');
 
 Returns **(Button | null)** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/panels/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/panels/config/config.ts
 
 [2]: #addpanel
 

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -81,7 +81,7 @@ const res = Parser.parseCss('.cls { color: red }');
 
 Returns **[Array][9]<[Object][5]>** Array containing the result
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/parser/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/parser/config/config.ts
 
 [2]: #getconfig
 

--- a/docs/api/rich_text_editor.md
+++ b/docs/api/rich_text_editor.md
@@ -162,7 +162,7 @@ Returns **[HTMLElement][11]**
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
 
-[2]: https://github.com/artf/grapesjs/blob/master/src/rich_text_editor/config/config.ts
+[2]: https://github.com/GrapesJS/grapesjs/blob/master/src/rich_text_editor/config/config.ts
 
 [3]: #add
 

--- a/docs/api/selector_manager.md
+++ b/docs/api/selector_manager.md
@@ -283,7 +283,7 @@ Get all selectors
 
 Returns **Collection<[Selector]>** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/selector_manager/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/selector_manager/config/config.ts
 
 [2]: #getconfig
 

--- a/docs/api/storage_manager.md
+++ b/docs/api/storage_manager.md
@@ -188,7 +188,7 @@ editor.loadProjectData(data);
 
 Returns **[Object][16]** Loaded data.
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/storage_manager/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.ts
 
 [2]: #getconfig
 

--- a/docs/api/style_manager.md
+++ b/docs/api/style_manager.md
@@ -386,7 +386,7 @@ Get all types
 
 Returns **[Array][27]** 
 
-[1]: https://github.com/artf/grapesjs/blob/master/src/style_manager/config/config.ts
+[1]: https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.ts
 
 [2]: #getconfig
 

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -16,13 +16,13 @@ mkdir docs-new
 mv `\ls -1 ./ | grep -v docs-new` ./docs-new
 
 # fetch the current site, remove the old docs dir and make current the new one
-git clone -b gh-pages https://github.com/artf/grapesjs.git tmp && mv tmp/* tmp/.* . && rm -rf tmp
+git clone -b gh-pages https://github.com/GrapesJS/grapesjs.git tmp && mv tmp/* tmp/.* . && rm -rf tmp
 rm -fR docs
 mv ./docs-new ./docs
 
 # stage all and commit
 git add -A
 git commit -m 'deploy docs'
-git push https://artf@github.com/artf/grapesjs.git gh-pages
+git push https://artf@github.com/GrapesJS/grapesjs.git gh-pages
 # surge --domain grapesjs.surge.sh
 cd -

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -602,7 +602,7 @@ Check out the [Device Manager API](api/device_manager.html) to see all the avail
 
 ## Store & load data
 Once you have finished with defining your builder interface the next step would be to setup the storing and loading process.
-GrapesJS implements 2 simple type of storages inside its Storage Manager: The local (by using `localStorage`, active by default) and the remote one. Those are enough to cover most of the cases, but it's also possible to add new implementations ([grapesjs-indexeddb](https://github.com/GrapesJS/grapesjs-indexeddb) is a good example).
+GrapesJS implements 2 simple type of storages inside its Storage Manager: The local (by using `localStorage`, active by default) and the remote one. Those are enough to cover most of the cases, but it's also possible to add new implementations ([grapesjs-indexeddb](https://github.com/GrapesJS/storage-indexeddb) is a good example).
 Let's see how the default options work:
 
 ```js

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -424,7 +424,7 @@ editor.Commands.add('show-styles', {
   <DemoStyle/>
 </Demo>
 
-Inside Style Manager definition we use `buildProps` which helps us create common properties from [available built-in objects](modules/Style-manager.html#built-in-properties) then in `properties` we can override same objects (eg. passing another `name` to change the label) identified by `property` name. As you can see from `custom-prop` example it's a matter of defining the CSS `property` and the input `type`. We suggest to check a more complete example of Style Manager properties usage from the [webpage preset demo](https://github.com/artf/grapesjs/blob/gh-pages/demo.html#L1000).
+Inside Style Manager definition we use `buildProps` which helps us create common properties from [available built-in objects](modules/Style-manager.html#built-in-properties) then in `properties` we can override same objects (eg. passing another `name` to change the label) identified by `property` name. As you can see from `custom-prop` example it's a matter of defining the CSS `property` and the input `type`. We suggest to check a more complete example of Style Manager properties usage from the [webpage preset demo](https://github.com/GrapesJS/grapesjs/blob/gh-pages/demo.html#L1000).
 
 ::: tip
 Check the [Style Manager API](api/panels.html) to see how to update sectors and properties dynamically.
@@ -602,7 +602,7 @@ Check out the [Device Manager API](api/device_manager.html) to see all the avail
 
 ## Store & load data
 Once you have finished with defining your builder interface the next step would be to setup the storing and loading process.
-GrapesJS implements 2 simple type of storages inside its Storage Manager: The local (by using `localStorage`, active by default) and the remote one. Those are enough to cover most of the cases, but it's also possible to add new implementations ([grapesjs-indexeddb](https://github.com/artf/grapesjs-indexeddb) is a good example).
+GrapesJS implements 2 simple type of storages inside its Storage Manager: The local (by using `localStorage`, active by default) and the remote one. Those are enough to cover most of the cases, but it's also possible to add new implementations ([grapesjs-indexeddb](https://github.com/GrapesJS/grapesjs-indexeddb) is a good example).
 Let's see how the default options work:
 
 ```js
@@ -669,7 +669,7 @@ If you prefer you could also disable the autosaving and use a custom command to 
 To get a better overview of the Storage Manager and how you should store/load the template, or how to define new storages you should read the [Storage Manager Module](modules/Storage.html) page.
 
 ## Theming
-One last step that might actually improve a lot your editor personality is how it looks visually. To achieve an easy theming we have adapted an atomic design for this purpose. To customize the main palette of colors all you have to do is to change few CSS rules. Alternatively if you include GrapesJS styles via SCSS you can make use of its [internal variables](https://github.com/artf/grapesjs/blob/dev/src/styles/scss/_gjs_variables.scss) and declare your variables before the import:
+One last step that might actually improve a lot your editor personality is how it looks visually. To achieve an easy theming we have adapted an atomic design for this purpose. To customize the main palette of colors all you have to do is to change few CSS rules. Alternatively if you include GrapesJS styles via SCSS you can make use of its [internal variables](https://github.com/GrapesJS/grapesjs/blob/dev/src/styles/scss/_gjs_variables.scss) and declare your variables before the import:
 
 ```scss
 // Put your variables before the GrapesJS style import

--- a/docs/guides/Custom-CSS-parser.md
+++ b/docs/guides/Custom-CSS-parser.md
@@ -3,7 +3,7 @@ title: Use Custom CSS Parser
 ---
 # Use Custom CSS Parser
 
-If you just use GrapesJS for building templates from scratch, so you start from an empty canvas and for editing you strictly rely  on the generated JSON (final HTML/CSS only for end-users) then, probably, you might skip this guide. On the other hand, if you import templates from already defined HTML/CSS or let the user embed custom codes (eg. using the [grapesjs-custom-code](https://github.com/GrapesJS/grapesjs-custom-code) plugin), then you have to know that you might face strange behaviors.
+If you just use GrapesJS for building templates from scratch, so you start from an empty canvas and for editing you strictly rely  on the generated JSON (final HTML/CSS only for end-users) then, probably, you might skip this guide. On the other hand, if you import templates from already defined HTML/CSS or let the user embed custom codes (eg. using the [grapesjs-custom-code](https://github.com/GrapesJS/components-custom-code) plugin), then you have to know that you might face strange behaviors.
 
 ::: warning
 This guide requires GrapesJS v0.14.33 or higher
@@ -249,4 +249,4 @@ To make it more clear let's see a few examples
 
 Below the list of current available CSS parsers as plugins, if you need to create your own we highly suggest to explore their sources
 
-* [grapesjs-parser-postcss](https://github.com/GrapesJS/grapesjs-parser-postcss) - Using [PostCSS](https://github.com/postcss/postcss) parser
+* [grapesjs-parser-postcss](https://github.com/GrapesJS/parser-postcss) - Using [PostCSS](https://github.com/postcss/postcss) parser

--- a/docs/guides/Custom-CSS-parser.md
+++ b/docs/guides/Custom-CSS-parser.md
@@ -3,7 +3,7 @@ title: Use Custom CSS Parser
 ---
 # Use Custom CSS Parser
 
-If you just use GrapesJS for building templates from scratch, so you start from an empty canvas and for editing you strictly rely  on the generated JSON (final HTML/CSS only for end-users) then, probably, you might skip this guide. On the other hand, if you import templates from already defined HTML/CSS or let the user embed custom codes (eg. using the [grapesjs-custom-code](https://github.com/artf/grapesjs-custom-code) plugin), then you have to know that you might face strange behaviors.
+If you just use GrapesJS for building templates from scratch, so you start from an empty canvas and for editing you strictly rely  on the generated JSON (final HTML/CSS only for end-users) then, probably, you might skip this guide. On the other hand, if you import templates from already defined HTML/CSS or let the user embed custom codes (eg. using the [grapesjs-custom-code](https://github.com/GrapesJS/grapesjs-custom-code) plugin), then you have to know that you might face strange behaviors.
 
 ::: warning
 This guide requires GrapesJS v0.14.33 or higher
@@ -249,4 +249,4 @@ To make it more clear let's see a few examples
 
 Below the list of current available CSS parsers as plugins, if you need to create your own we highly suggest to explore their sources
 
-* [grapesjs-parser-postcss](https://github.com/artf/grapesjs-parser-postcss) - Using [PostCSS](https://github.com/postcss/postcss) parser
+* [grapesjs-parser-postcss](https://github.com/GrapesJS/grapesjs-parser-postcss) - Using [PostCSS](https://github.com/postcss/postcss) parser

--- a/docs/guides/Replace-Rich-Text-Editor.md
+++ b/docs/guides/Replace-Rich-Text-Editor.md
@@ -122,4 +122,4 @@ Obviously, each third-party library has its own APIs and can present some limita
 
 ## Plugins
 
-For the CKEditor, you can find a complete plugin here [grapesjs-plugin-ckeditor](https://github.com/artf/grapesjs-plugin-ckeditor).
+For the CKEditor, you can find a complete plugin here [grapesjs-plugin-ckeditor](https://github.com/GrapesJS/grapesjs-plugin-ckeditor).

--- a/docs/guides/Replace-Rich-Text-Editor.md
+++ b/docs/guides/Replace-Rich-Text-Editor.md
@@ -122,4 +122,4 @@ Obviously, each third-party library has its own APIs and can present some limita
 
 ## Plugins
 
-For the CKEditor, you can find a complete plugin here [grapesjs-plugin-ckeditor](https://github.com/GrapesJS/grapesjs-plugin-ckeditor).
+For the CKEditor, you can find a complete plugin here [grapesjs-plugin-ckeditor](https://github.com/GrapesJS/ckeditor).

--- a/docs/modules/Assets.md
+++ b/docs/modules/Assets.md
@@ -31,7 +31,7 @@ You can update most of them later by using `getConfig` inside of the module
 const amConfig = editor.AssetManager.getConfig();
 ```
 
-Check the full list of available options here: [Asset Manager Config](https://github.com/artf/grapesjs/blob/master/src/asset_manager/config/config.js)
+Check the full list of available options here: [Asset Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.js)
 
 
 
@@ -69,7 +69,7 @@ const editor = grapesjs.init({
 ```
 
 
-If you want a complete list of available properties check out the source [AssetImage Model](https://github.com/artf/grapesjs/blob/dev/src/asset_manager/model/AssetImage.js)
+If you want a complete list of available properties check out the source [AssetImage Model](https://github.com/GrapesJS/grapesjs/blob/dev/src/asset_manager/model/AssetImage.js)
 
 The built-in Asset Manager modal is implemented and is showing up when requested. By default, you can make it appear by dragging Image Components in canvas, double clicking on images and all other stuff related to images (eg. CSS styling)
 
@@ -454,7 +454,7 @@ am.addType('svg-icon', {
     // `getPreview()` and `getInfo()` are just few helpers, you can
     // override the entire template with `template()`
     // Check the base `template()` here:
-    // https://github.com/artf/grapesjs/blob/dev/src/asset_manager/view/AssetView.js
+    // https://github.com/GrapesJS/grapesjs/blob/dev/src/asset_manager/view/AssetView.js
     getPreview() {
       return `<div style="text-align: center">${this.model.get('svgContent')}</div>`;
     },
@@ -568,7 +568,7 @@ am.addType('image', {
   // but you can eventually extend some other type
   view: {
     // If you want to see more methods to extend check out
-    // https://github.com/artf/grapesjs/blob/dev/src/asset_manager/view/AssetImageView.js
+    // https://github.com/GrapesJS/grapesjs/blob/dev/src/asset_manager/view/AssetImageView.js
     onRemove(e) {
       e.stopPropagation();
       const model = this.model;

--- a/docs/modules/Blocks.md
+++ b/docs/modules/Blocks.md
@@ -33,7 +33,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Block Manager Config](https://github.com/artf/grapesjs/blob/master/src/block_manager/config/config.js)
+Check the full list of available options here: [Block Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.js)
 
 
 ## Initialization

--- a/docs/modules/Commands.md
+++ b/docs/modules/Commands.md
@@ -37,7 +37,7 @@ const editor = grapesjs.init({
 });
 ```
 
-For all other available options check directly the [configuration source file](https://github.com/artf/grapesjs/blob/dev/src/commands/config/config.js).
+For all other available options check directly the [configuration source file](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/config/config.js).
 
 Most commonly commands are created dynamically post-initialization, in that case, you'll need to use the [Commands API](/api/commands.html) (eg. this is what you need if you create a plugin)
 
@@ -93,25 +93,25 @@ Until now there is nothing exciting except a common entry point for functions, b
 
 GrapesJS comes along with some default set of commands and you can get a list of all currently available commands via `editor.Commands.getAll()`. This will give you an object of all available commands, so, also those added later, like via plugins. You can recognize default commands by their namespace `core:*`, we also recommend to use namespaces in your own custom commands, but let's get a look more in detail here:
 
-* [`core:canvas-clear`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/CanvasClear.js) - Clear all the content from the canvas (HTML and CSS)
-* [`core:component-delete`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/ComponentDelete.js) - Delete a component
-* [`core:component-enter`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/ComponentEnter.js) - Select the first children component of the selected one
-* [`core:component-exit`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/ComponentExit.js) - Select the parent component of the current selected one
-* [`core:component-next`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/ComponentNext.js) - Select the next sibling component
-* [`core:component-prev`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/ComponentPrev.js) - Select the previous sibling component
-* [`core:component-outline`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/SwitchVisibility.js) - Enable outline border on components
-* [`core:component-offset`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/ShowOffset.js) - Enable components offset (margins, paddings)
-* [`core:component-select`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/SelectComponent.js) - Enable the process of selecting components in the canvas
-* [`core:copy`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/CopyComponent.js) - Copy the current selected component
-* [`core:paste`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/PasteComponent.js) - Paste copied component
-* [`core:preview`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/Preview.js) - Show the preview of the template in canvas
-* [`core:fullscreen`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/Fullscreen.js) - Set the editor fullscreen
-* [`core:open-code`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/ExportTemplate.js) - Open a default panel with the template code
-* [`core:open-layers`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/OpenLayers.js) - Open a default panel with layers
-* [`core:open-styles`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/OpenStyleManager.js) - Open a default panel with the style manager
-* [`core:open-traits`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/OpenTraitManager.js) - Open a default panel with the trait manager
-* [`core:open-blocks`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/OpenBlocks.js) - Open a default panel with the blocks
-* [`core:open-assets`](https://github.com/artf/grapesjs/blob/dev/src/commands/view/OpenAssets.js) - Open a default panel with the assets
+* [`core:canvas-clear`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/CanvasClear.js) - Clear all the content from the canvas (HTML and CSS)
+* [`core:component-delete`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/ComponentDelete.js) - Delete a component
+* [`core:component-enter`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/ComponentEnter.js) - Select the first children component of the selected one
+* [`core:component-exit`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/ComponentExit.js) - Select the parent component of the current selected one
+* [`core:component-next`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/ComponentNext.js) - Select the next sibling component
+* [`core:component-prev`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/ComponentPrev.js) - Select the previous sibling component
+* [`core:component-outline`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/SwitchVisibility.js) - Enable outline border on components
+* [`core:component-offset`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/ShowOffset.js) - Enable components offset (margins, paddings)
+* [`core:component-select`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/SelectComponent.js) - Enable the process of selecting components in the canvas
+* [`core:copy`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/CopyComponent.js) - Copy the current selected component
+* [`core:paste`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/PasteComponent.js) - Paste copied component
+* [`core:preview`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/Preview.js) - Show the preview of the template in canvas
+* [`core:fullscreen`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/Fullscreen.js) - Set the editor fullscreen
+* [`core:open-code`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/ExportTemplate.js) - Open a default panel with the template code
+* [`core:open-layers`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/OpenLayers.js) - Open a default panel with layers
+* [`core:open-styles`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/OpenStyleManager.js) - Open a default panel with the style manager
+* [`core:open-traits`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/OpenTraitManager.js) - Open a default panel with the trait manager
+* [`core:open-blocks`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/OpenBlocks.js) - Open a default panel with the blocks
+* [`core:open-assets`](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/view/OpenAssets.js) - Open a default panel with the assets
 * `core:undo` - Call undo operation
 * `core:redo` - Call redo operation
 <!-- * `core:canvas-move` -->

--- a/docs/modules/Components.md
+++ b/docs/modules/Components.md
@@ -189,24 +189,24 @@ A more advanced use case of custom components is an implementation of a custom r
 
 Here below you can see the list of built-in component types, ordered by their position in the **Component Type Stack**
 
-* [`cell`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentTableCell.js) - Component for handle `<td>` and `<th>` elements
-* [`row`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentTableRow.js) - Component for handle `<tr>` elements
-* [`table`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentTable.js) - Component for handle `<table>` elements
-* [`thead`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentTableHead.js) - Component for handle `<thead>` elements
-* [`tbody`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentTableBody.js) - Component for handle `<tbody>` elements
-* [`tfoot`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentTableFoot.js) - Component for handle `<tfoot>` elements
-* [`map`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentMap.js) - Component for handle `<a>` elements
-* [`link`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentLink.js) - Component for handle `<a>` elements
-* [`label`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentLabel.js) - Component for handle properly `<label>` elements
-* [`video`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentVideo.js) - Component for videos
-* [`image`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentImage.js) - Component for images
-* [`script`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentScript.js) - Component for handle `<script>` elements
-* [`svg`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentSvg.js) - Component for handle SVG elements
-* [`comment`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentComment.js) - Component for comments (might be useful for email editors)
-* [`textnode`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentTextNode.js) - Similar to the textnode in DOM definition, so a text element without a tag element.
-* [`text`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentText.js) - A simple text component that can be edited inline
-* [`wrapper`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/ComponentWrapper.js) - The canvas need to contain a root component, a wrapper, this component was made to identify it
-* [`default`](https://github.com/artf/grapesjs/blob/dev/src/dom_components/model/Component.js) - Default base component
+* [`cell`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentTableCell.js) - Component for handle `<td>` and `<th>` elements
+* [`row`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentTableRow.js) - Component for handle `<tr>` elements
+* [`table`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentTable.js) - Component for handle `<table>` elements
+* [`thead`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentTableHead.js) - Component for handle `<thead>` elements
+* [`tbody`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentTableBody.js) - Component for handle `<tbody>` elements
+* [`tfoot`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentTableFoot.js) - Component for handle `<tfoot>` elements
+* [`map`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentMap.js) - Component for handle `<a>` elements
+* [`link`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentLink.js) - Component for handle `<a>` elements
+* [`label`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentLabel.js) - Component for handle properly `<label>` elements
+* [`video`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentVideo.js) - Component for videos
+* [`image`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentImage.js) - Component for images
+* [`script`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentScript.js) - Component for handle `<script>` elements
+* [`svg`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentSvg.js) - Component for handle SVG elements
+* [`comment`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentComment.js) - Component for comments (might be useful for email editors)
+* [`textnode`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentTextNode.js) - Similar to the textnode in DOM definition, so a text element without a tag element.
+* [`text`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentText.js) - A simple text component that can be edited inline
+* [`wrapper`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/ComponentWrapper.js) - The canvas need to contain a root component, a wrapper, this component was made to identify it
+* [`default`](https://github.com/GrapesJS/grapesjs/blob/dev/src/dom_components/model/Component.js) - Default base component
 
 
 

--- a/docs/modules/I18n.md
+++ b/docs/modules/I18n.md
@@ -155,7 +155,7 @@ If you want to support GrapesJS by adding a new language to our repository all y
 ## Plugin development
 
 ::: warning
-This section is dedicated **only** to plugin developers and can also be skipped in case you use [grapesjs-cli](https://github.com/GrapesJS/grapesjs-cli) to init your plugin project
+This section is dedicated **only** to plugin developers and can also be skipped in case you use [grapesjs-cli](https://github.com/GrapesJS/cli) to init your plugin project
 :::
 
 If you're developing a plugin for GrapesJS and you need to support some string localization or simply change the default one, we recommend the following structure.
@@ -207,7 +207,7 @@ export default (editor, opts = {}) => {
 The next step would be to compile your locale files into `<rootDir>/locale` directory to make them easily accessible by your users. This folder could be ignored in your git repository be should be deployd to the npm registry
 
 ::: warning
-Remember that you can skip all these long steps and init your project with [grapesjs-cli](https://github.com/GrapesJS/grapesjs-cli). This will create all the necessary folders/files/commands for you (during `init` command this step is flagged `true` by default and we recommend to keep it even in case the i18n is not required in your project)
+Remember that you can skip all these long steps and init your project with [grapesjs-cli](https://github.com/GrapesJS/cli). This will create all the necessary folders/files/commands for you (during `init` command this step is flagged `true` by default and we recommend to keep it even in case the i18n is not required in your project)
 :::
 
 

--- a/docs/modules/I18n.md
+++ b/docs/modules/I18n.md
@@ -142,8 +142,8 @@ We need to find the way to update the UI
 
 If you want to support GrapesJS by adding a new language to our repository all you need to do is to follow steps below:
 
-1. First of all, be sure to check the language file in [`src/i18n/locale`](https://github.com/artf/grapesjs/blob/master/src/i18n/locale) doesn't exist already
-1. [Open a new issue](https://github.com/artf/grapesjs/issues/new?title=XX%20Language%20support) to avoid overlap with other contributos. To be sure, check also no one else has opened already an issue for the same language
+1. First of all, be sure to check the language file in [`src/i18n/locale`](https://github.com/GrapesJS/grapesjs/blob/master/src/i18n/locale) doesn't exist already
+1. [Open a new issue](https://github.com/GrapesJS/grapesjs/issues/new?title=XX%20Language%20support) to avoid overlap with other contributos. To be sure, check also no one else has opened already an issue for the same language
 1. Start a new branch from `dev`
 1. Copy (in the same folder) and rename the [`en` locale file] to the name of your language of choice (be sure to be compliant to [ISO 639-1])
 1. Now you can start translating strings
@@ -155,7 +155,7 @@ If you want to support GrapesJS by adding a new language to our repository all y
 ## Plugin development
 
 ::: warning
-This section is dedicated **only** to plugin developers and can also be skipped in case you use [grapesjs-cli](https://github.com/artf/grapesjs-cli) to init your plugin project
+This section is dedicated **only** to plugin developers and can also be skipped in case you use [grapesjs-cli](https://github.com/GrapesJS/grapesjs-cli) to init your plugin project
 :::
 
 If you're developing a plugin for GrapesJS and you need to support some string localization or simply change the default one, we recommend the following structure.
@@ -207,7 +207,7 @@ export default (editor, opts = {}) => {
 The next step would be to compile your locale files into `<rootDir>/locale` directory to make them easily accessible by your users. This folder could be ignored in your git repository be should be deployd to the npm registry
 
 ::: warning
-Remember that you can skip all these long steps and init your project with [grapesjs-cli](https://github.com/artf/grapesjs-cli). This will create all the necessary folders/files/commands for you (during `init` command this step is flagged `true` by default and we recommend to keep it even in case the i18n is not required in your project)
+Remember that you can skip all these long steps and init your project with [grapesjs-cli](https://github.com/GrapesJS/grapesjs-cli). This will create all the necessary folders/files/commands for you (during `init` command this step is flagged `true` by default and we recommend to keep it even in case the i18n is not required in your project)
 :::
 
 
@@ -233,4 +233,4 @@ const editor = grapesjs.init({
 ```
 
 [ISO 639-1]: <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>
-[`en` locale file]: <https://github.com/artf/grapesjs/blob/master/src/i18n/locale/en.js>
+[`en` locale file]: <https://github.com/GrapesJS/grapesjs/blob/master/src/i18n/locale/en.js>

--- a/docs/modules/Layers.md
+++ b/docs/modules/Layers.md
@@ -28,7 +28,7 @@ const editor = grapesjs.init({
 });
 ```
 
-You can check here the full list of available configuration options: [Layer Manager Config](https://github.com/artf/grapesjs/blob/master/src/navigator/config/config.ts)
+You can check here the full list of available configuration options: [Layer Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/navigator/config/config.ts)
 
 
 Layers are a direct representation of your components, therefore they will only be available once your components are loaded in the editor (eg. you might load your project data from a remote endpoint).

--- a/docs/modules/Plugins.md
+++ b/docs/modules/Plugins.md
@@ -142,10 +142,10 @@ In this example, the plugin name is `my-plugin-name` and can't be used by other 
 
 ## Boilerplate
 
-For fast plugin development, we highly recommend using [grapesjs-cli](https://github.com/artf/grapesjs-cli) which helps to avoid the hassle of setting up all the dependencies and configurations for development and building (no need to touch Webpack o Babel configurations). For more information check the repository
+For fast plugin development, we highly recommend using [grapesjs-cli](https://github.com/GrapesJS/grapesjs-cli) which helps to avoid the hassle of setting up all the dependencies and configurations for development and building (no need to touch Webpack o Babel configurations). For more information check the repository
 
 
 ## Popular Plugins
 
- - https://github.com/artf/grapesjs-preset-webpage
- - https://github.com/artf/grapesjs-preset-newsletter
+ - https://github.com/GrapesJS/grapesjs-preset-webpage
+ - https://github.com/GrapesJS/grapesjs-preset-newsletter

--- a/docs/modules/Plugins.md
+++ b/docs/modules/Plugins.md
@@ -142,10 +142,10 @@ In this example, the plugin name is `my-plugin-name` and can't be used by other 
 
 ## Boilerplate
 
-For fast plugin development, we highly recommend using [grapesjs-cli](https://github.com/GrapesJS/grapesjs-cli) which helps to avoid the hassle of setting up all the dependencies and configurations for development and building (no need to touch Webpack o Babel configurations). For more information check the repository
+For fast plugin development, we highly recommend using [grapesjs-cli](https://github.com/GrapesJS/cli) which helps to avoid the hassle of setting up all the dependencies and configurations for development and building (no need to touch Webpack o Babel configurations). For more information check the repository
 
 
 ## Popular Plugins
 
- - https://github.com/GrapesJS/grapesjs-preset-webpage
- - https://github.com/GrapesJS/grapesjs-preset-newsletter
+ - https://github.com/GrapesJS/preset-webpage
+ - https://github.com/GrapesJS/preset-newsletter

--- a/docs/modules/Selectors.md
+++ b/docs/modules/Selectors.md
@@ -29,7 +29,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Selector Manager Config](https://github.com/artf/grapesjs/blob/master/src/selector_manager/config/config.ts)
+Check the full list of available options here: [Selector Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/selector_manager/config/config.ts)
 
 
 ## Initialization

--- a/docs/modules/Storage.md
+++ b/docs/modules/Storage.md
@@ -443,8 +443,8 @@ For a complete list of available events, you can check it [here](/api/storage_ma
 
 
 
-[grapesjs-indexeddb]: <https://github.com/GrapesJS/grapesjs-indexeddb>
-[grapesjs-firestore]: <https://github.com/GrapesJS/grapesjs-firestore>
+[grapesjs-indexeddb]: <https://github.com/GrapesJS/storage-indexeddb>
+[grapesjs-firestore]: <https://github.com/GrapesJS/storage-firestore>
 [localStorage API]: <https://developer.mozilla.org/it/docs/Web/API/Window/localStorage>
 [IndexedDB  API]: <https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API>
 [json-server]: <https://github.com/typicode/json-server>

--- a/docs/modules/Storage.md
+++ b/docs/modules/Storage.md
@@ -43,7 +43,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Storage Manager Config](https://github.com/artf/grapesjs/blob/master/src/storage_manager/config/config.js)
+Check the full list of available options here: [Storage Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.js)
 
 
 
@@ -443,8 +443,8 @@ For a complete list of available events, you can check it [here](/api/storage_ma
 
 
 
-[grapesjs-indexeddb]: <https://github.com/artf/grapesjs-indexeddb>
-[grapesjs-firestore]: <https://github.com/artf/grapesjs-firestore>
+[grapesjs-indexeddb]: <https://github.com/GrapesJS/grapesjs-indexeddb>
+[grapesjs-firestore]: <https://github.com/GrapesJS/grapesjs-firestore>
 [localStorage API]: <https://developer.mozilla.org/it/docs/Web/API/Window/localStorage>
 [IndexedDB  API]: <https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API>
 [json-server]: <https://github.com/typicode/json-server>

--- a/docs/modules/Style-manager.md
+++ b/docs/modules/Style-manager.md
@@ -32,7 +32,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Style Manager Config](https://github.com/artf/grapesjs/blob/master/src/style_manager/config/config.js)
+Check the full list of available options here: [Style Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.js)
 
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -182,7 +182,7 @@ declare namespace grapesjs {
      * following the HTML flow. Two other options are available:
      * 'absolute' - Move components absolutely (design tools way)
      * 'translate' - Use translate CSS from transform property
-     * To get more about this feature read: https://github.com/artf/grapesjs/issues/1936 */
+     * To get more about this feature read: https://github.com/GrapesJS/grapesjs/issues/1936 */
     dragMode?: 'translate' | 'absolute';
 
     /** When the editor is placed in a scrollable container (eg. modals) this might
@@ -779,7 +779,7 @@ declare namespace grapesjs {
 
   /**
    * Editor contains the top level API which you'll probably use to customize the editor or extend it with plugins.
-   * You get the Editor instance on init method and you can pass options via its [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/editor/config/config.js)
+   * You get the Editor instance on init method and you can pass options via its [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/editor/config/config.js)
    *
    * ```js
    * const editor = grapesjs.init({
@@ -1175,7 +1175,7 @@ declare namespace grapesjs {
     setCustomParserCss(parser: ((...params: any[]) => any) | null): Editor;
     /**
      * Change the global drag mode of components.
-     * To get more about this feature read: https://github.com/artf/grapesjs/issues/1936
+     * To get more about this feature read: https://github.com/GrapesJS/grapesjs/issues/1936
      * @param value - Drag mode, options: 'absolute' | 'translate'
      */
     setDragMode(value: string): Editor;
@@ -1367,7 +1367,7 @@ declare namespace grapesjs {
   type GeneralEvent = 'canvasScroll' | 'undo' | 'redo' | 'load' | 'update';
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/asset_manager/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  assetManager: {
@@ -1579,7 +1579,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/block_manager/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  blockManager: {
@@ -1805,7 +1805,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/commands/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/commands/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  commands: {
@@ -1964,7 +1964,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * With this module is possible to manage components inside the canvas. You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/dom_components/config/config.js)
+   * With this module is possible to manage components inside the canvas. You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/dom_components/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  domComponents: {
@@ -2225,7 +2225,7 @@ declare namespace grapesjs {
      */
     copyable?: boolean;
     /**
-     * Indicates if it's possible to resize the component. It's also possible to pass an object as [options for the Resizer](https://github.com/artf/grapesjs/blob/master/src/utils/Resizer.js). Default: `false`
+     * Indicates if it's possible to resize the component. It's also possible to pass an object as [options for the Resizer](https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.js). Default: `false`
      */
     resizable?: boolean;
     /**
@@ -2382,7 +2382,7 @@ declare namespace grapesjs {
 
     /**
      * Change the drag mode of the component.
-     * To get more about this feature read: https://github.com/artf/grapesjs/issues/1936
+     * To get more about this feature read: https://github.com/GrapesJS/grapesjs/issues/1936
      * @param value - Drag mode, options: 'absolute' | 'translate'
      */
     setDragMode(value: string): this;
@@ -2794,7 +2794,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/panels/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/panels/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  panels: {
@@ -2921,7 +2921,7 @@ declare namespace grapesjs {
 
   /**
    * With Style Manager you build categories (called sectors) of CSS properties which could be used to customize the style of components.
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/style_manager/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  styleManager: {
@@ -3811,7 +3811,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/storage_manager/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  storageManager: {
@@ -3962,7 +3962,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/device_manager/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/device_manager/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  deviceManager: {
@@ -4110,7 +4110,7 @@ declare namespace grapesjs {
    *
    * So, for example, being `btn` the same class entity it'll be easier to refactor and track things.
    *
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/selector_manager/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/selector_manager/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  selectorManager: {
@@ -4353,7 +4353,7 @@ declare namespace grapesjs {
 
   /**
    * This module manages CSS rules in the canvas.
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/css_composer/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/css_composer/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  cssComposer: {
@@ -4624,7 +4624,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/modal_dialog/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/modal_dialog/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  modal: {
@@ -4752,7 +4752,7 @@ declare namespace grapesjs {
    * This module allows to customize the built-in toolbar of the Rich Text Editor and use commands from the [HTML Editing APIs](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand).
    * It's highly recommended to keep this toolbar as small as possible, especially from styling commands (eg. 'fontSize') and leave this task to the Style Manager
    *
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/rich_text_editor/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/rich_text_editor/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  richTextEditor: {
@@ -5117,7 +5117,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/canvas/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/canvas/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  canvas: {
@@ -5309,7 +5309,7 @@ declare namespace grapesjs {
   interface Frame extends Backbone.Model<FrameOptions> { }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/i18n/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/i18n/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  i18n: {
@@ -5574,7 +5574,7 @@ declare namespace grapesjs {
   }
 
   /**
-   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/parser/config/config.js)
+   * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/parser/config/config.js)
    * ```js
    * const editor = grapesjs.init({
    *  parser: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/artf/grapesjs.git"
+    "url": "https://github.com/GrapesJS/grapesjs.git"
   },
   "dependencies": {
     "backbone": "1.4.1",

--- a/src/asset_manager/index.ts
+++ b/src/asset_manager/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/asset_manager/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  assetManager: {

--- a/src/block_manager/index.ts
+++ b/src/block_manager/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/block_manager/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  blockManager: {

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/canvas/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/canvas/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  canvas: {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/commands/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/commands/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  commands: {

--- a/src/css_composer/index.ts
+++ b/src/css_composer/index.ts
@@ -1,6 +1,6 @@
 /**
  * This module manages CSS rules in the canvas.
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/css_composer/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/css_composer/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  cssComposer: {

--- a/src/device_manager/index.ts
+++ b/src/device_manager/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/device_manager/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/device_manager/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  deviceManager: {

--- a/src/dom_components/index.ts
+++ b/src/dom_components/index.ts
@@ -1,5 +1,5 @@
 /**
- * With this module is possible to manage components inside the canvas. You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/dom_components/config/config.ts)
+ * With this module is possible to manage components inside the canvas. You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/dom_components/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  domComponents: {

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -86,7 +86,7 @@ export const keyUpdateInside = `${keyUpdate}-inside`;
  * @property {Array<String>} [unstylable=[]] Indicate an array of style properties which should be hidden from the style manager. Default: `[]`
  * @property {Boolean} [highlightable=true] It can be highlighted with 'dotted' borders if true. Default: `true`
  * @property {Boolean} [copyable=true] True if it's possible to clone the component. Default: `true`
- * @property {Boolean} [resizable=false] Indicates if it's possible to resize the component. It's also possible to pass an object as [options for the Resizer](https://github.com/artf/grapesjs/blob/master/src/utils/Resizer.js). Default: `false`
+ * @property {Boolean} [resizable=false] Indicates if it's possible to resize the component. It's also possible to pass an object as [options for the Resizer](https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.js). Default: `false`
  * @property {Boolean} [editable=false] Allow to edit the content of the component (used on Text components). Default: `false`
  * @property {Boolean} [layerable=true] Set to `false` if you need to hide the component inside Layers. Default: `true`
  * @property {Boolean} [selectable=true] Allow component to be selected when clicked. Default: `true`
@@ -350,7 +350,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
 
   /**
    * Change the drag mode of the component.
-   * To get more about this feature read: https://github.com/artf/grapesjs/issues/1936
+   * To get more about this feature read: https://github.com/GrapesJS/grapesjs/issues/1936
    * @param {String} value Drag mode, options: 'absolute' | 'translate'
    * @returns {this}
    */

--- a/src/dom_components/model/types.ts
+++ b/src/dom_components/model/types.ts
@@ -84,7 +84,7 @@ export interface ComponentProperties {
    */
   copyable?: boolean;
   /**
-   * Indicates if it's possible to resize the component. It's also possible to pass an object as [options for the Resizer](https://github.com/artf/grapesjs/blob/master/src/utils/Resizer.js). Default: `false`
+   * Indicates if it's possible to resize the component. It's also possible to pass an object as [options for the Resizer](https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.js). Default: `false`
    */
   resizable?: boolean | ResizerOptions;
   /**

--- a/src/dom_components/view/ToolbarButtonView.ts
+++ b/src/dom_components/view/ToolbarButtonView.ts
@@ -40,8 +40,8 @@ export default class ToolbarButtonView extends View<ToolbarButton> {
      * This makes sure the offsets are calculated.
      *
      * More information on
-     * https://github.com/artf/grapesjs/issues/2372
-     * https://github.com/artf/grapesjs/issues/2207
+     * https://github.com/GrapesJS/grapesjs/issues/2372
+     * https://github.com/GrapesJS/grapesjs/issues/2207
      */
 
     const { em } = this;

--- a/src/editor/config/config.ts
+++ b/src/editor/config/config.ts
@@ -273,7 +273,7 @@ export interface EditorConfig {
    * following the HTML flow. Two other options are available:
    * 'absolute' - Move components absolutely (design tools way)
    * 'translate' - Use translate CSS from transform property
-   * To get more about this feature read: https://github.com/artf/grapesjs/issues/1936.
+   * To get more about this feature read: https://github.com/GrapesJS/grapesjs/issues/1936.
    */
   dragMode?: 'translate' | 'absolute';
 

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -1,6 +1,6 @@
 /**
  * Editor contains the top level API which you'll probably use to customize the editor or extend it with plugins.
- * You get the Editor instance on init method and you can pass options via its [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/editor/config/config.ts)
+ * You get the Editor instance on init method and you can pass options via its [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/editor/config/config.ts)
  *
  * ```js
  * const editor = grapesjs.init({
@@ -678,7 +678,7 @@ export default class Editor implements IBaseModule<EditorConfig> {
 
   /**
    * Change the global drag mode of components.
-   * To get more about this feature read: https://github.com/artf/grapesjs/issues/1936
+   * To get more about this feature read: https://github.com/GrapesJS/grapesjs/issues/1936
    * @param {String} value Drag mode, options: 'absolute' | 'translate'
    * @returns {this}
    */

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/i18n/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/i18n/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  i18n: {

--- a/src/modal_dialog/index.ts
+++ b/src/modal_dialog/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/modal_dialog/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/modal_dialog/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  modal: {

--- a/src/panels/index.ts
+++ b/src/panels/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/panels/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/panels/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  panels: {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/parser/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/parser/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  parser: {

--- a/src/rich_text_editor/index.ts
+++ b/src/rich_text_editor/index.ts
@@ -2,7 +2,7 @@
  * This module allows to customize the built-in toolbar of the Rich Text Editor and use commands from the [HTML Editing APIs](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand).
  * It's highly recommended to keep this toolbar as small as possible, especially from styling commands (eg. 'fontSize') and leave this task to the Style Manager
  *
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/rich_text_editor/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/rich_text_editor/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  richTextEditor: {

--- a/src/selector_manager/index.ts
+++ b/src/selector_manager/index.ts
@@ -20,7 +20,7 @@
  *
  * So, for example, being `btn` the same class entity it'll be easier to refactor and track things.
  *
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/selector_manager/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/selector_manager/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  selectorManager: {

--- a/src/storage_manager/index.ts
+++ b/src/storage_manager/index.ts
@@ -1,5 +1,5 @@
 /**
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/storage_manager/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  storageManager: {

--- a/src/style_manager/index.ts
+++ b/src/style_manager/index.ts
@@ -1,6 +1,6 @@
 /**
  * With Style Manager you build categories (called sectors) of CSS properties which could be used to customize the style of components.
- * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/artf/grapesjs/blob/master/src/style_manager/config/config.ts)
+ * You can customize the initial state of the module from the editor initialization, by passing the following [Configuration Object](https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.ts)
  * ```js
  * const editor = grapesjs.init({
  *  styleManager: {

--- a/src/utils/Sorter.ts
+++ b/src/utils/Sorter.ts
@@ -476,13 +476,13 @@ export default class Sorter extends View {
     }
 
     // Prevents loops in Firefox
-    // https://github.com/artf/grapesjs/issues/2911
+    // https://github.com/GrapesJS/grapesjs/issues/2911
     if (source && source === model) return;
 
     const { targetModel } = this;
 
     // Reset the previous model but not if it's the same as the source
-    // https://github.com/artf/grapesjs/issues/2478#issuecomment-570314736
+    // https://github.com/GrapesJS/grapesjs/issues/2478#issuecomment-570314736
     if (targetModel && targetModel !== this.srcModel) {
       targetModel.set('status', '');
     }

--- a/src/utils/polyfills.ts
+++ b/src/utils/polyfills.ts
@@ -1,6 +1,6 @@
 /**
  * File made for IE/Edge support
- * https://github.com/artf/grapesjs/issues/214
+ * https://github.com/GrapesJS/grapesjs/issues/214
  */
 import { hasWin } from './mixins';
 


### PR DESCRIPTION
fix #4912

Ok, this is what I did

* artf/grapesjs => GrapesJS/grapesjs
* exception of the github pages urls: http://artf.github.io/grapesjs/demo.html => https://grapesjs.com/demo.html
* exception of the plugins: 
  1. https://github.com/GrapesJS/grapesjs-plugin-export => https://github.com/GrapesJS/export
  2. https://github.com/GrapesJS/grapesjs-aviary => https://github.com/GrapesJS/aviary
* https://github.com/artf/grapesjs-indexeddb => https://github.com/GrapesJS/storage-indexeddb
* https://github.com/artf/grapesjs-firestore => https://github.com/GrapesJS/storage-firestore
* https://github.com/artf/grapesjs-custom-code => https://github.com/GrapesJS/components-custom-code
* https://github.com/artf/grapesjs-plugin-ckeditor => https://github.com/GrapesJS/ckeditor
