### PR TITLE
TS Types: Extends the type of property that scripts/styles can takes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -406,8 +406,8 @@ declare namespace grapesjs {
 
   interface CanvasConfig {
     stylePrefix?: string;
-    scripts?: Array<string>;
-    styles?: Array<string>;
+    scripts?: Array<string | Record<string, string>>;
+    styles?: Array<string | Record<string, string>>;
     customBadgeLabel?: Function;
     autoscrollLimit?: number;
     notTextable?: Array<string>;


### PR DESCRIPTION
In the typescripts file, the `scripts` and `style` properties in the Canvas configuration currently accept arrays of string. But should also be able to take objects whose properties will be HTML attributes like in this example below:

#### It works
```ts
editor.Canvas.getConfig().scripts.push('path/to/my/scripts.js')
```
#### Error: Argument of type '{ src: string; title: string; }' is not assignable to parameter of type 'string'.ts

``` ts
editor.Canvas.getConfig().scripts.push({
      src: 'path/to/my/scripts.js',
      title: 'My HTML Title',
}) 
```