### PR TITLE
Fix broken links in the docs

### DIFF
--- a/docs/modules/Assets.md
+++ b/docs/modules/Assets.md
@@ -31,7 +31,7 @@ You can update most of them later by using `getConfig` inside of the module
 const amConfig = editor.AssetManager.getConfig();
 ```
 
-Check the full list of available options here: [Asset Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.js)
+Check the full list of available options here: [Asset Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.ts)
 
 
 

--- a/docs/modules/Blocks.md
+++ b/docs/modules/Blocks.md
@@ -33,7 +33,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Block Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.js)
+Check the full list of available options here: [Block Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.ts)
 
 
 ## Initialization

--- a/docs/modules/Commands.md
+++ b/docs/modules/Commands.md
@@ -37,7 +37,7 @@ const editor = grapesjs.init({
 });
 ```
 
-For all other available options check directly the [configuration source file](https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/config/config.js).
+For all other available options check directly the [configuration source file](https://github.com/GrapesJS/grapesjs/blob/master/src/commands/config/config.ts).
 
 Most commonly commands are created dynamically post-initialization, in that case, you'll need to use the [Commands API](/api/commands.html) (eg. this is what you need if you create a plugin)
 

--- a/docs/modules/Storage.md
+++ b/docs/modules/Storage.md
@@ -43,7 +43,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Storage Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.js)
+Check the full list of available options here: [Storage Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.ts)
 
 
 

--- a/docs/modules/Style-manager.md
+++ b/docs/modules/Style-manager.md
@@ -32,7 +32,7 @@ const editor = grapesjs.init({
 });
 ```
 
-Check the full list of available options here: [Style Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.js)
+Check the full list of available options here: [Style Manager Config](https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.ts)
 
 
 


### PR DESCRIPTION
Fixes #4962 

This is what I did

Changed javascript file links in configuration object to typescript files 
https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.js => https://github.com/GrapesJS/grapesjs/blob/master/src/storage_manager/config/config.ts

https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.js => https://github.com/GrapesJS/grapesjs/blob/master/src/block_manager/config/config.ts

https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.js => https://github.com/GrapesJS/grapesjs/blob/master/src/style_manager/config/config.ts

https://github.com/GrapesJS/grapesjs/blob/dev/src/commands/config/config.js => https://github.com/GrapesJS/grapesjs/blob/master/src/commands/config/config.ts

https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.js => https://github.com/GrapesJS/grapesjs/blob/master/src/asset_manager/config/config.ts
