### PR TITLE
Options while exporting code/template

### DIFF
--- a/src/commands/view/ExportTemplate.ts
+++ b/src/commands/view/ExportTemplate.ts
@@ -2,7 +2,7 @@ import { CommandObject } from './CommandAbstract';
 import { $ } from '../../common';
 
 export default {
-  run(editor, sender) {
+  run(editor, sender, opts = {}) {
     sender && sender.set && sender.set('active', 0);
     const config = editor.getConfig();
     const modal = editor.Modal;
@@ -26,8 +26,8 @@ export default {
       })
       .getModel()
       .once('change:open', () => editor.stopCommand(`${this.id}`));
-    this.htmlEditor.setContent(editor.getHtml());
-    this.cssEditor.setContent(editor.getCss());
+    this.htmlEditor.setContent(editor.getHtml(opts));
+    this.cssEditor.setContent(editor.getCss(opts));
   },
 
   stop(editor) {

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -601,7 +601,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
    * Return all component's attributes
    * @return {Object}
    */
-  getAttributes(opts: { noClass?: boolean; noStyle?: boolean } = {}) {
+  getAttributes(opts: { noClass?: boolean; noStyle?: boolean; noId?: boolean } = {}) {
     const { em } = this;
     const classes: string[] = [];
     const attributes = { ...this.get('attributes') };
@@ -625,7 +625,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
     }
 
     // Check if we need an ID on the component
-    if (!has(attributes, 'id')) {
+    if (!has(attributes, 'id') && !opts.noId) {
       let addId;
 
       // If we don't rely on inline styling we have to check


### PR DESCRIPTION
I had to provide "opts"
`editor.runCommand('core:open-code', opts)`
while exporting code but I guess its missing in "ExportTemplate.js" file...

The code on line 204
![image](https://user-images.githubusercontent.com/52742115/226398340-cf85fa46-9926-4168-9979-97281013f13a.png)
will run and pass options (args) 
which in turn runs this code:
![image](https://user-images.githubusercontent.com/52742115/226398700-003e4deb-c0ea-4fd6-b836-fea0d71a04ba.png)
but "getHtml" was not passing options...


