### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ To showcase the power of GrapesJS we have created some presets.
 
 * [grapesjs-preset-webpage](https://github.com/GrapesJS/preset-webpage) - [Webpage Builder](https://grapesjs.com/demo.html)
 * [grapesjs-preset-newsletter](https://github.com/GrapesJS/preset-newsletter) - [Newsletter Builder](https://grapesjs.com/demo-newsletter-editor.html)
-* [grapesjs-mjml](https://github.com/GrapesJS/mjml) - [Newsletter Builder with MJML](https://grapesjs/demo-mjml.html)
+* [grapesjs-mjml](https://github.com/GrapesJS/mjml) - [Newsletter Builder with MJML](https://grapesjs.com/demo-mjml.html)
 
 You can actually use them as a starting point for your editors, so, just follow the instructions on their repositories to get a quick start for your builder.
 


### PR DESCRIPTION
added ".com" in a not functioning link.