### PR TITLE
resolves #5357

### DIFF
--- a/src/rich_text_editor/model/RichTextEditor.ts
+++ b/src/rich_text_editor/model/RichTextEditor.ts
@@ -9,7 +9,7 @@ import { getModel } from '../../utils/mixins';
 
 export interface RichTextEditorAction {
   name: string;
-  icon: string;
+  icon: string | HTMLElement;
   event?: string;
   attributes?: Record<string, any>;
   result: (rte: RichTextEditor, action: RichTextEditorAction) => void;


### PR DESCRIPTION
updating the type of RichTextEditorAction.icon to be "string | HTMLElement"