### PR TITLE
#5462 Added ability to preselect active page upon loading the project

### DIFF
--- a/src/canvas/model/Canvas.ts
+++ b/src/canvas/model/Canvas.ts
@@ -42,7 +42,7 @@ export default class Canvas extends ModuleModel<CanvasModule> {
 
   init() {
     const { em } = this;
-    const mainPage = em.Pages.getMain();
+    const mainPage = em.Pages.getPreselectedPage() || em.Pages.getMain();
     this.set('frames', mainPage.getFrames());
     this.updateDevice({ frame: mainPage.getMainFrame() });
   }

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -89,6 +89,7 @@ const pageEvents = {
 
 export interface PageManagerConfig extends ModuleConfig {
   pages?: any[];
+  activePage?: string;
 }
 
 export default class PageManager extends ItemManagerModule<PageManagerConfig, Pages> {
@@ -226,6 +227,15 @@ export default class PageManager extends ItemManagerModule<PageManagerConfig, Pa
   getMain() {
     const { pages } = this;
     return pages.filter(p => p.get('type') === typeMain)[0] || pages.at(0);
+  }
+
+  getPreselectedPage() {
+    const { pages, config } = this;
+    if (config.activePage) {
+      return pages.find(p => p.getId() === config.activePage);
+    } else {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
This PR introduces a new configuration option for the `PageManager`:

```
pageManager: {
  activePage: 'initial-page-id-goes-here',
  pages: [ /*...*/ ],
},
```

It is useful when you want to start editing a specific page rather than the one with `{ type: 'main' }`, e.g. when you use GrapesJS as the editor only and the page being edited is dictated by an external source.

To test it, add the following to your configuration:

```
        pageManager: {
          activePage: 'test-page-2',
          pages: [
            { id: 'test-page-1', type: 'main', component: { content: '<h1>Test page 1</h1>' } },
            { id: 'test-page-2', component: { content: '<h1>Test page 2</h1>' } },
          ]
        }
```

which will cause the second page to be active immediately rather than the first one, with `{ type: 'main' }`
