### PR TITLE
Fix component script param parse if its a function 

### DIFF
--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -1801,7 +1801,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
       if (isFunction(scr)) {
         let scrStr = scr.toString().trim();
         scrStr = scrStr.slice(scrStr.indexOf('{') + 1, scrStr.lastIndexOf('}'));
-        scr = scrStr.trim();
+        scr = scrStr.replaceAll('_this', 'this').trim();
       }
 
       const config = this.em.getConfig();


### PR DESCRIPTION
I tried to add script param for a component but it was having an error
```
const script = ()=>{
  const el: HTMLDivElement = this as any;
  console.log(el.id)
  // this is bound to the component element
  console.log('the element', this);
};
```
because it was converted to:
```
ƒ () {
    var el = _this;
    console.log(el.id);
    // this is bound to the component element
    console.log('the element', _this);
}
```
