### PR TITLE
AssetManager: Configurable upload name suffix for multi file uploads

### DIFF
--- a/src/asset_manager/config/config.ts
+++ b/src/asset_manager/config/config.ts
@@ -46,10 +46,15 @@ export interface AssetManagerConfig {
    */
   credentials?: RequestCredentials;
   /**
-   * Allow uploading multiple files per request. If disabled filename will not have '[]' appended.
+   * Allow uploading multiple files per request. If disabled filename will not have the 'multiUploadSuffix' appended.
    * @default true
    */
   multiUpload?: boolean;
+  /**
+   * The suffix to append to 'uploadName' when 'multiUpload' is true.
+   * @default '[]'
+   */
+  multiUploadSuffix?: string;
   /**
    * If true, tries to add automatically uploaded assets. To make it work the server should respond with a JSON containing assets in a data key, eg:
    * { data: [ 'https://.../image.png', {src: 'https://.../image2.png'} ]
@@ -146,6 +151,7 @@ const config: AssetManagerConfig = {
   params: {},
   credentials: 'include',
   multiUpload: true,
+  multiUploadSuffix: '[]',
   autoAdd: true,
   customFetch: undefined,
   uploadFile: undefined,

--- a/src/asset_manager/view/FileUploader.ts
+++ b/src/asset_manager/view/FileUploader.ts
@@ -155,7 +155,7 @@ export default class FileUploaderView extends View {
 
     if (this.multiUpload) {
       for (let i = 0; i < files.length; i++) {
-        body.append(`${config.uploadName}[]`, files[i]);
+        body.append(`${config.uploadName}${config.multiUploadSuffix}`, files[i]);
       }
     } else if (files.length) {
       body.append(config.uploadName!, files[0]);


### PR DESCRIPTION
This PR adds the option `multiUploadSuffix` to the `AssetManagerConfig`. This makes it possible to replace the currently hard-coded value `[]` with a custom one or just an empty string. 

To ensure the change causes no breakage for existing setups, the value of `multiUploadSuffix` defaults to `[]`. Developers who would like to have another or no suffix at all can change it to their needs.

A related issue was raised already in #693, but closed with the argument, that the `name` property of a `Content-Disposition` line represents an array. I know the brackets are common practice in PHP, where they are processed as an indicator for an [array of uploaded files](https://www.php.net/manual/en/features.file-upload.multiple.php), so there is a valid case for the brackets being there. The reasoning for this patch is, that in ASP.NET there is an integrated type (`IFormFileCollection`) that can receive `multi-part/form-data`-uploads. When using it, the file list is automatically mapped to the variable with a name that matches `name` property. This mechanism fails, because the variable name contains brackets. 

There is a workaround for ASP.NET, but that requires maintaining a "manual" extraction of the files from the incoming request or creating a middle ware. Using a framework provided method is less work, more reliable and secure. Especially because we're dealing with binary file uploads here.