### PR TITLE
Move out Script generation logic from the Component

### DIFF
--- a/src/canvas/view/CanvasView.ts
+++ b/src/canvas/view/CanvasView.ts
@@ -584,7 +584,7 @@ export default class CanvasView extends ModuleView<Canvas> {
       // those will not be available immediately, therefore 'item' variable
       const script = document.createElement('script');
       const scriptFn = scriptComponent.getScriptString();
-      const scriptFnStr = model.get('script-props') ? scriptFn : `function(){\n${scriptFn}\n;}`;
+      const scriptFnStr = scriptComponent.props ? scriptFn : `function(){\n${scriptFn}\n;}`;
       const scriptProps = JSON.stringify(scriptComponent.__getScriptProps());
       script.innerHTML = `
       setTimeout(function() {

--- a/src/canvas/view/CanvasView.ts
+++ b/src/canvas/view/CanvasView.ts
@@ -566,8 +566,7 @@ export default class CanvasView extends ModuleView<Canvas> {
    * @param {ModuleView} view Component's View
    * @private
    */
-  //TODO change type after the ComponentView was updated to ts
-  updateScript(view: any) {
+  updateScript(view: ComponentView) {
     const model = view.model;
     const id = model.getId();
 
@@ -577,26 +576,29 @@ export default class CanvasView extends ModuleView<Canvas> {
       jsEl?.appendChild(view.scriptContainer);
     }
 
-    view.el.id = id;
-    view.scriptContainer.innerHTML = '';
-    // In editor, I make use of setTimeout as during the append process of elements
-    // those will not be available immediately, therefore 'item' variable
-    const script = document.createElement('script');
-    const scriptFn = model.getScriptString();
-    const scriptFnStr = model.get('script-props') ? scriptFn : `function(){\n${scriptFn}\n;}`;
-    const scriptProps = JSON.stringify(model.__getScriptProps());
-    script.innerHTML = `
+    const scriptComponent = model.scriptSubComp;
+    if (scriptComponent) {
+      view.el.id = id;
+      view.scriptContainer.innerHTML = '';
+      // In editor, I make use of setTimeout as during the append process of elements
+      // those will not be available immediately, therefore 'item' variable
+      const script = document.createElement('script');
+      const scriptFn = scriptComponent.getScriptString();
+      const scriptFnStr = model.get('script-props') ? scriptFn : `function(){\n${scriptFn}\n;}`;
+      const scriptProps = JSON.stringify(scriptComponent.__getScriptProps());
+      script.innerHTML = `
       setTimeout(function() {
         var item = document.getElementById('${id}');
         if (!item) return;
         (${scriptFnStr}.bind(item))(${scriptProps})
       }, 1);`;
-    // #873
-    // Adding setTimeout will make js components work on init of the editor
-    setTimeout(() => {
-      const scr = view.scriptContainer;
-      scr?.appendChild(script);
-    }, 0);
+      // #873
+      // Adding setTimeout will make js components work on init of the editor
+      setTimeout(() => {
+        const scr = view.scriptContainer;
+        scr?.appendChild(script);
+      }, 0);
+    }
   }
 
   /**

--- a/src/code_manager/model/JsGenerator.ts
+++ b/src/code_manager/model/JsGenerator.ts
@@ -18,7 +18,7 @@ export default class JsGenerator extends Model {
 
   mapModel(model: Component) {
     let code = '';
-    const script = model.get('script-export') || model.get('script');
+    const script = model.scriptSubComp;
     const type = model.get('type')!;
     const comps = model.get('components')!;
     const id = model.getId();
@@ -28,19 +28,19 @@ export default class JsGenerator extends Model {
       let attr = model.get('attributes');
       attr = extend({}, attr, { id });
       model.set('attributes', attr, { silent: true });
-      // @ts-ignore
-      const scrStr = model.getScriptString(script);
-      const scrProps = model.get('script-props');
+
+      const scrStr = script.getScriptString();
+      const scrProps = script.props;
 
       // If the script was updated, I'll put its code in a separate container
-      if (model.get('scriptUpdated') && !scrProps) {
+      if (script.get('scriptUpdated') && !scrProps) {
         this.mapJs[type + '-' + id] = { ids: [id], code: scrStr };
       } else {
         let props;
         const mapType = this.mapJs[type];
 
         if (scrProps) {
-          props = model.__getScriptProps();
+          props = script.__getScriptProps();
         }
 
         if (mapType) {

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -1079,7 +1079,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
 
     let scriptData: ScriptData | string | ((...params: any[]) => any) | undefined =
       this.get('script-export') || (this.get('script') as any);
-    if (!isUndefined(scriptData)) {
+    if (scriptData) {
       if (isString(scriptData) || isFunction(scriptData)) {
         scriptData = { main: scriptData, props: this.get('script-props') ?? [] };
       }

--- a/src/dom_components/model/modules/ScriptSubComponent.ts
+++ b/src/dom_components/model/modules/ScriptSubComponent.ts
@@ -1,0 +1,114 @@
+import { isArray, isFunction } from 'underscore';
+import { Model } from '../../../common';
+import Component from '../Component';
+import { ComponentProperties } from '../types';
+
+export interface ScriptData {
+  main: string | ((...params: any[]) => any);
+  props: string[];
+}
+const escapeRegExp = (str: string) => {
+  return str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+};
+
+export default class ScriptSubComponent extends Model {
+  //@ts-ignore
+  get defaults() {
+    return {
+      main: '',
+      props: '',
+      scriptUpdated: false,
+    };
+  }
+
+  constructor(component: Component, script: ScriptData) {
+    super({ component, ...script });
+    this.listenTo(this, 'change:main', this.scriptUpdated);
+  }
+
+  get component() {
+    return this.get('component');
+  }
+
+  get props(): string[] {
+    return this.get('props');
+  }
+
+  initScriptProps() {
+    const { component } = this;
+    const prop = 'props';
+    const toListen: any = [`change:${prop}`, this.initScriptProps];
+    this.off(...toListen);
+    const prevProps: string[] = this.previous(prop) || [];
+    const newProps: string[] = this.get(prop) || [];
+    const prevPropsEv = prevProps.map(e => `change:${e}`).join(' ');
+    const newPropsEv = newProps.map(e => `change:${e}`).join(' ');
+    prevPropsEv && component.off(prevPropsEv, this.__scriptPropsChange);
+    newPropsEv && component.on(newPropsEv, this.__scriptPropsChange);
+    // @ts-ignore
+    this.on(...toListen);
+  }
+
+  __scriptPropsChange(m: any, v: any, opts: any = {}) {
+    if (opts.avoidStore) return;
+    this.component.trigger('rerender');
+  }
+
+  /**
+   * Script updated
+   * @private
+   */
+  scriptUpdated() {
+    this.set('scriptUpdated', true);
+  }
+
+  __getScriptProps() {
+    const modelProps = this.component.props();
+    const scrProps = this.props || [];
+    return scrProps.reduce((acc, prop) => {
+      acc[prop] = modelProps[prop];
+      return acc;
+    }, {} as Partial<ComponentProperties>);
+  }
+
+  /**
+   * Return script in string format, cleans 'function() {..' from scripts
+   * if it's a function
+   * @param {string|Function} script
+   * @return {string}
+   * @private
+   */
+  getScriptString(script?: string | Function) {
+    const { component } = this;
+    let scr: string = script || this.get('main') || '';
+
+    if (!scr) {
+      return scr;
+    }
+
+    if (this.props) {
+      scr = scr.toString().trim();
+    } else {
+      // Deprecated
+      // Need to convert script functions to strings
+      if (isFunction(scr)) {
+        let scrStr = scr.toString().trim();
+        scrStr = scrStr.slice(scrStr.indexOf('{') + 1, scrStr.lastIndexOf('}'));
+        scr = scrStr.trim();
+      }
+
+      const config = component.em.getConfig();
+      const tagVarStart = escapeRegExp(config.tagVarStart || '{[ ');
+      const tagVarEnd = escapeRegExp(config.tagVarEnd || ' ]}');
+      const reg = new RegExp(`${tagVarStart}([\\w\\d-]*)${tagVarEnd}`, 'g');
+      scr = scr.replace(reg, (match, v) => {
+        // If at least one match is found I have to track this change for a
+        // better optimization inside JS generator
+        this.scriptUpdated();
+        const result = component.attributes[v] || '';
+        return isArray(result) || typeof result == 'object' ? JSON.stringify(result) : result;
+      });
+    }
+    return scr;
+  }
+}

--- a/src/dom_components/model/modules/ScriptSubComponent.ts
+++ b/src/dom_components/model/modules/ScriptSubComponent.ts
@@ -12,11 +12,10 @@ const escapeRegExp = (str: string) => {
 };
 
 export default class ScriptSubComponent extends Model {
-  //@ts-ignore
-  get defaults() {
+  defaults() {
     return {
       main: '',
-      props: '',
+      props: [],
       scriptUpdated: false,
     };
   }
@@ -37,7 +36,7 @@ export default class ScriptSubComponent extends Model {
   initScriptProps() {
     const { component } = this;
     const prop = 'props';
-    const toListen: any = [`change:${prop}`, this.initScriptProps];
+    const toListen: any = [`change:${prop}`, this.initScriptProps, this];
     this.off(...toListen);
     const prevProps: string[] = this.previous(prop) || [];
     const newProps: string[] = this.get(prop) || [];

--- a/src/dom_components/model/types.ts
+++ b/src/dom_components/model/types.ts
@@ -10,6 +10,7 @@ import ComponentView from '../view/ComponentView';
 import Component from './Component';
 import Components from './Components';
 import { ToolbarButtonProps } from './ToolbarButton';
+import { ScriptData } from './modules/ScriptSubComponent';
 
 export type DragMode = 'translate' | 'absolute' | '';
 
@@ -18,7 +19,7 @@ export type DraggableDroppableFn = (source: Component, target: Component, index?
 export interface ComponentStackItem {
   id: string;
   model: typeof Component;
-  view: typeof ComponentView<any>;
+  view: typeof ComponentView;
 }
 
 /**
@@ -187,7 +188,7 @@ export interface ComponentProperties {
    * Component's javascript. More about it [here](/modules/Components-js.html). Default: `''`
    * @default ''
    */
-  script?: string | ((...params: any[]) => any);
+  script?: string | ((...params: any[]) => any) | ScriptData;
   ///**
   // * You can specify javascript available only in export functions (eg. when you get the HTML).
   //If this property is defined it will overwrite the `script` one (in export functions). Default: `''`

--- a/src/dom_components/model/types.ts
+++ b/src/dom_components/model/types.ts
@@ -16,10 +16,10 @@ export type DragMode = 'translate' | 'absolute' | '';
 
 export type DraggableDroppableFn = (source: Component, target: Component, index?: number) => boolean | void;
 
-export interface ComponentStackItem {
+export interface ComponentStackItem<TComp extends Component = Component> {
   id: string;
-  model: typeof Component;
-  view: typeof ComponentView;
+  model: new (props: any, opt: ComponentOptions) => TComp;
+  view: new (opt: any) => ComponentView<TComp>;
 }
 
 /**

--- a/src/dom_components/view/ComponentView.ts
+++ b/src/dom_components/view/ComponentView.ts
@@ -392,7 +392,7 @@ TComp> {
    */
   updateScript() {
     const { model, em } = this;
-    if (!model.get('script')) return;
+    if (!model.scriptSubComp) return;
     em?.Canvas.getCanvasView().updateScript(this);
   }
 


### PR DESCRIPTION
I think the Component contains to much logic and it is hard to comprehend all of its features,
I would want to add some other functionality for the script generation part but it happen in multiple places the component, JsGenerator and the CanvasView I would like to move all of it into the ScriptSubComponent first I just moved from the Component so I could do the changes incrementally.