### PR TITLE
docs: Fix broken link of Resizer

### DIFF
--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -859,7 +859,7 @@ Returns **[Boolean][3]**
 
 [5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[6]: https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.js
+[6]: https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.ts
 
 [7]: /modules/Components-js.html
 


### PR DESCRIPTION
Fixes #5715 

This is what I did

Changed javascript file links in configuration object to typescript files
https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.js => https://github.com/GrapesJS/grapesjs/blob/master/src/utils/Resizer.ts