### PR TITLE
Always place the tools above the highlighter

### DIFF
--- a/src/styles/scss/_gjs_canvas.scss
+++ b/src/styles/scss/_gjs_canvas.scss
@@ -271,6 +271,10 @@ $guide_pad: 5px !default;
     outline: none;
     z-index: 1;
   }
+  /* Always place the tools above the highlighter */
+  ##{$app-prefix}tools {
+    z-index: 2;
+  }
 
   /* This simulate body behaviour */
   // > div:first-child {


### PR DESCRIPTION
Component highlight indicators display above RTE tools on hover. This sets the z-index 1 above the indicators.

Current:
![image](https://github.com/GrapesJS/grapesjs/assets/1020507/b9c74cf9-20ef-4864-83b5-2ad25704c0fc)

Proposed:
![image](https://github.com/GrapesJS/grapesjs/assets/1020507/2f0b5ea1-4361-4113-923b-8cdd8b7adc9b)
