### PR TITLE
Update InputColor to append at the body instead of the editor

### DIFF
--- a/src/domain_abstract/ui/InputColor.ts
+++ b/src/domain_abstract/ui/InputColor.ts
@@ -103,7 +103,7 @@ export default class InputColor extends Input {
 
       var colorEl = $(`<div class="${this.ppfx}field-color-picker"></div>`);
       var cpStyle = colorEl.get(0)!.style;
-      var elToAppend = em && em.config ? em.config.el : '';
+      var elToAppend = $('body');
       var colorPickerConfig = (em && em.getConfig && em.getConfig().colorPicker) || {};
 
       this.movedColor = '';
@@ -123,7 +123,7 @@ export default class InputColor extends Input {
       // @ts-ignore
       colorEl.spectrum({
         color: model.getValue() || false,
-        containerClassName: `${ppfx}one-bg ${ppfx}two-color`,
+        containerClassName: `${ppfx}one-bg ${ppfx}two-color ${ppfx}editor-sp`,
         appendTo: elToAppend || 'body',
         maxSelectionSize: 8,
         showPalette: true,

--- a/src/styles/scss/main.scss
+++ b/src/styles/scss/main.scss
@@ -444,7 +444,13 @@ $colorsAll: (one, var(--gjs-primary-color)),
 
 /********* Spectrum **********/
 
-.#{$app-prefix}editor-cont {
+.#{$app-prefix}editor-sp {
+  border: 1px solid var(--gjs-main-dark-color);
+  box-shadow: 0 0 7px var(--gjs-main-dark-color);
+  border-radius: 3px;
+}
+
+.#{$app-prefix}editor-sp {
   .sp-hue, .sp-slider{ cursor: row-resize;}
   .sp-color, .sp-dragger{ cursor: crosshair;}
   .sp-alpha-inner, .sp-alpha-handle{cursor: col-resize;}


### PR DESCRIPTION
The addresses an issue where we are trying to place a popover palette absolutely positioned over a InputColor element at an arbitrary location on the page. And we need to do this even when the origin element is outside of the editor container node.

To meet this requirement, the popover palette can not be contained anywhere within an offsetParent, and further it must be at the highest z-index. Otherwise it will be subject to the visible area of it's offsetParent and ordered by the parent's z-index. So we are adding that container directly to the `body`. 
