### PR TITLE
Move last selected component

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -141,7 +141,7 @@ export default class CommandsModule extends Module<CommandsConfig & { pStylePref
         const trg = opts.target as Component | undefined;
         const trgs = trg ? [trg] : [...ed.getSelectedAll()];
         const targets = trgs.map(trg => trg.delegate?.move?.(trg) || trg).filter(Boolean);
-        const target = targets[0] as Component | undefined;
+        const target = targets[targets.length - 1] as Component | undefined;
         const nativeDrag = event?.type === 'dragstart';
         const modes = ['absolute', 'translate'];
 


### PR DESCRIPTION
In absolute mode, there is a discrepancy between the toolbar, which is shown on the latest selected element, and the moving command, which is triggered on the first selected one.

**Before**

![before](https://github.com/GrapesJS/grapesjs/assets/73150750/c06f4046-530c-4851-b6de-35324d317ca2)

**After**

![after](https://github.com/GrapesJS/grapesjs/assets/73150750/bfcf6197-76ca-4744-a0a8-5500d3d5cb2f)


