### PR TITLE
Show style applied on tag (p, span, div) and private selectors as parent rules instead of hiding them

### DIFF
--- a/src/i18n/locale/id.js
+++ b/src/i18n/locale/id.js
@@ -1,0 +1,169 @@
+const traitInputAttr = { placeholder: 'cth. Ketik disini' };
+
+export default {
+  assetManager: {
+    addButton: 'Tambah gambar',
+    inputPlh: 'http://path/menuju/gambar.jpg',
+    modalTitle: 'Pilih Gambar',
+    uploadTitle: 'Tarik gambar kesini atau klik upload',
+  },
+  // Here just as a reference, GrapesJS core doesn't contain any block,
+  // so this should be omitted from other local files
+  blockManager: {
+    labels: {
+      // 'block-id': 'Block Label',
+    },
+    categories: {
+      // 'category-id': 'Category Label',
+    },
+  },
+  domComponents: {
+    names: {
+      '': 'Kotak',
+      wrapper: 'Badan',
+      text: 'Teks',
+      comment: 'Komentar',
+      image: 'Gambar',
+      video: 'Video',
+      label: 'Label',
+      link: 'Link',
+      map: 'Peta',
+      tfoot: 'Kaki tabel',
+      tbody: 'Badan tabel',
+      thead: 'Kepala tabel',
+      table: 'Tabel',
+      row: 'Baris tabel',
+      cell: 'Cell tabel',
+    },
+  },
+  deviceManager: {
+    device: 'Perangkat',
+    devices: {
+      desktop: 'Desktop',
+      tablet: 'Tablet',
+      mobileLandscape: 'Mobile Landscape',
+      mobilePortrait: 'Mobile Portrait',
+    },
+  },
+  panels: {
+    buttons: {
+      titles: {
+        preview: 'Pra-tayang',
+        fullscreen: 'Tampilan penuh',
+        'sw-visibility': 'Lihat komponen',
+        'export-template': 'Lihat kode',
+        'open-sm': 'Buka Manajemen Style',
+        'open-tm': 'Pengaturan',
+        'open-layers': 'Buka Layer Manager',
+        'open-blocks': 'Buka Blocks',
+      },
+    },
+  },
+  selectorManager: {
+    label: 'Class',
+    selected: 'Terpilih',
+    emptyState: '- State -',
+    states: {
+      hover: 'Hover',
+      active: 'Klik',
+      'nth-of-type(2n)': 'Rata/Ganjil',
+    },
+  },
+  styleManager: {
+    empty: 'Pilih elemen sebelum menggunakan Manajemen Style',
+    layer: 'Layer',
+    fileButton: 'Gambar',
+    sectors: {
+      general: 'Umum',
+      layout: 'Pemetaan',
+      typography: 'Tipografi',
+      decorations: 'Dekorasi',
+      extra: 'Ekstra',
+      flex: 'Flex',
+      dimension: 'Dimensi',
+    },
+    // Default names for sub properties in Composite and Stack types.
+    // Other labels are generated directly from their property names (eg. 'font-size' will be 'Font size').
+    properties: {
+      'text-shadow-h': 'X',
+      'text-shadow-v': 'Y',
+      'text-shadow-blur': 'Blur',
+      'text-shadow-color': 'Warna',
+      'box-shadow-h': 'X',
+      'box-shadow-v': 'Y',
+      'box-shadow-blur': 'Blur',
+      'box-shadow-spread': 'Spread',
+      'box-shadow-color': 'Warna',
+      'box-shadow-type': 'Tipe',
+      'margin-top-sub': 'Atas',
+      'margin-right-sub': 'Kanan',
+      'margin-bottom-sub': 'Bawah',
+      'margin-left-sub': 'Kiri',
+      'padding-top-sub': 'Atas',
+      'padding-right-sub': 'Kanan',
+      'padding-bottom-sub': 'Bawah',
+      'padding-left-sub': 'Kiri',
+      'border-width-sub': 'Panjang',
+      'border-style-sub': 'Gaya',
+      'border-color-sub': 'Warna',
+      'border-top-left-radius-sub': 'Atas Kiri',
+      'border-top-right-radius-sub': 'Atas Kanan',
+      'border-bottom-right-radius-sub': 'Bawah Kanan',
+      'border-bottom-left-radius-sub': 'Bawah Kiri',
+      'transform-rotate-x': 'Putar X',
+      'transform-rotate-y': 'Putar Y',
+      'transform-rotate-z': 'Putar Z',
+      'transform-scale-x': 'Scale X',
+      'transform-scale-y': 'Scale Y',
+      'transform-scale-z': 'Scale Z',
+      'transition-property-sub': 'Properti',
+      'transition-duration-sub': 'Durasi',
+      'transition-timing-function-sub': 'Timing',
+      'background-image-sub': 'Gambar',
+      'background-repeat-sub': 'Berulang',
+      'background-position-sub': 'Posisi',
+      'background-attachment-sub': 'Lampiran',
+      'background-size-sub': 'Ukuran',
+    },
+    // Translate options in style properties
+    // options: {
+    //   float: { // Id of the property
+    //     ...
+    //     left: 'Left', // {option id}: {Option label}
+    //   }
+    // }
+  },
+  traitManager: {
+    empty: 'Pilih elemen terlebih dulu sebelum menggunakan Manajemen Trait',
+    label: 'Pengaturan komponen',
+    categories: {
+      categoryId: 'Label kategori'
+    },
+    traits: {
+      // The core library generates the name by their `name` property
+      labels: {
+        title: 'Judul',
+        href: 'Url (href)'
+        // id: 'Id',
+        // alt: 'Alt',
+      },
+      // In a simple trait, like text input, these are used on input attributes
+      attributes: {
+        id: traitInputAttr,
+        alt: traitInputAttr,
+        title: traitInputAttr,
+        href: { placeholder: 'cth. https://google.com' },
+      },
+      // In a trait like select, these are used to translate option names
+      options: {
+        target: {
+          false: 'Jendela ini',
+          _blank: 'Jendela baru',
+        },
+      },
+    },
+  },
+  storageManager: {
+    recover: 'Apakah kamu ingin mengembalikan draft yang belum tersimpan?',
+  },
+};

--- a/src/style_manager/index.ts
+++ b/src/style_manager/index.ts
@@ -81,7 +81,8 @@ import StyleableModel, { StyleProps } from '../domain_abstract/model/StyleableMo
 import { CustomPropertyView } from './view/PropertyView';
 import { PropertySelectProps } from './model/PropertySelect';
 import { PropertyNumberProps } from './model/PropertyNumber';
-import { PropertyStackProps } from './model/PropertyStack';
+import PropertyStack, { PropertyStackProps } from './model/PropertyStack';
+import PropertyComposite from './model/PropertyComposite';
 
 export type PropertyTypes = PropertyStackProps | PropertySelectProps | PropertyNumberProps;
 
@@ -309,7 +310,7 @@ export default class StyleManager extends ItemManagerModule<
    */
   addProperty(sectorId: string, property: PropertyTypes, opts: AddOptions = {}): Property | undefined {
     const sector = this.getSector(sectorId, { warn: true });
-    let prop = null;
+    let prop;
     if (sector) prop = sector.addProperty(property, opts);
 
     return prop;
@@ -522,7 +523,7 @@ export default class StyleManager extends ItemManagerModule<
    *  options: [{ id: 'value1', label: 'Some label' }, ...],
    * })
    */
-  addBuiltIn(prop: string, definition: Omit<PropertyProps, 'property'> & { proeperty?: 'string' }) {
+  addBuiltIn(prop: string, definition: PropertyProps) {
     return this.builtIn.add(prop, definition);
   }
 
@@ -597,6 +598,7 @@ export default class StyleManager extends ItemManagerModule<
       const optsSel = { array: true } as const;
       let cmpRules: CssRule[] = [];
       let tagNameRules: CssRule[] = [];
+      let invisibleRules: CssRule[] = [];
       let otherRules: CssRule[] = [];
       let rules: CssRule[] = [];
 
@@ -641,8 +643,19 @@ export default class StyleManager extends ItemManagerModule<
       } else {
         cmpRules = sel ? cssC.getRules(`#${sel.getId()}`) : [];
         tagNameRules = rulesByTagName(sel?.get('tagName') || '');
+        // Get rules set on active and visible selectors
         otherRules = rulesBySelectors(target.getSelectors().getFullName(optsSel));
-        rules = tagNameRules.concat(cmpRules).concat(otherRules);
+        // Get rules set on invisible selectors like private one
+        const allCmpClasses = sel?.getSelectors().getFullName(optsSel) || [];
+        const invisibleSel = allCmpClasses.filter(
+          (item: string) =>
+            target
+              .getSelectors()
+              .getFullName(optsSel)
+              .findIndex(sel => sel === item) === -1
+        );
+        invisibleRules = rulesBySelectors(invisibleSel);
+        rules = tagNameRules.concat(cmpRules).concat(invisibleRules).concat(otherRules);
       }
 
       const all = rules
@@ -813,7 +826,7 @@ export default class StyleManager extends ItemManagerModule<
     });
   }
 
-  __upProp(prop: any, style: StyleProps, parentStyles: any[], opts: any) {
+  __upProp(prop: Property, style: StyleProps, parentStyles: any[], opts: any) {
     const name = prop.getName();
     const value = style[name];
     const hasVal = propDef(value);
@@ -821,19 +834,21 @@ export default class StyleManager extends ItemManagerModule<
     const isComposite = prop.getType() === 'composite';
     const opt = { ...opts, __up: true };
     const canUpdate = !isComposite && !isStack;
-    let newLayers = isStack ? prop.__getLayersFromStyle(style) : [];
-    let newProps = isComposite ? prop.__getPropsFromStyle(style) : {};
+    const propStack = prop as PropertyStack;
+    const propComp = prop as PropertyComposite;
+    let newLayers = isStack ? propStack.__getLayersFromStyle(style) : [];
+    let newProps = isComposite ? propComp.__getPropsFromStyle(style) : {};
     let newValue = hasVal ? value : null;
     let parentTarget: any = null;
 
     if ((isStack && newLayers === null) || (isComposite && newProps === null)) {
       const method = isStack ? '__getLayersFromStyle' : '__getPropsFromStyle';
-      const parentItem = parentStyles.filter(p => prop[method](p.style) !== null)[0];
+      const parentItem = parentStyles.filter(p => propStack[method](p.style) !== null)[0];
 
       if (parentItem) {
         newValue = parentItem.style[name];
         parentTarget = parentItem.target;
-        const val = prop[method](parentItem.style);
+        const val = propStack[method](parentItem.style);
         if (isStack) {
           newLayers = val;
         } else {
@@ -851,22 +866,26 @@ export default class StyleManager extends ItemManagerModule<
     }
 
     prop.__setParentTarget(parentTarget);
-    canUpdate && prop.__getFullValue() !== newValue && prop.upValue(newValue, opt);
-    isStack && prop.__setLayers(newLayers || []);
+    canUpdate && prop.__getFullValue() !== newValue && prop.upValue(newValue as string, opt);
+    if (isStack) {
+      propStack.__setLayers(newLayers || [], {
+        isEmptyValue: propStack.isEmptyValueStyle(style),
+      });
+    }
     if (isComposite) {
-      const props = prop.getProperties();
+      const props = propComp.getProperties();
 
       // Detached has to be treathed as separate properties
-      if (prop.isDetached()) {
-        const newStyle = prop.__getPropsFromStyle(style, { byName: true }) || {};
+      if (propComp.isDetached()) {
+        const newStyle = propComp.__getPropsFromStyle(style, { byName: true }) || {};
         const newParentStyles = parentStyles.map(p => ({
           ...p,
-          style: prop.__getPropsFromStyle(p.style, { byName: true }) || {},
+          style: propComp.__getPropsFromStyle(p.style, { byName: true }) || {},
         }));
         props.map((pr: any) => this.__upProp(pr, newStyle, newParentStyles, opts));
       } else {
-        prop.__setProperties(newProps || {}, opt);
-        prop.getProperties().map((pr: any) => pr.__setParentTarget(parentTarget));
+        propComp.__setProperties(newProps || {}, opt);
+        propComp.getProperties().map(pr => pr.__setParentTarget(parentTarget));
       }
     }
   }

--- a/src/style_manager/index.ts
+++ b/src/style_manager/index.ts
@@ -618,20 +618,7 @@ export default class StyleManager extends ItemManagerModule<
       };
 
       const rulesByTagName = (tagName: string) => {
-        return cssC.getRules().filter(rule => {
-          const splittedRule = rule.selectorsToString().split(' ');
-          const ruleTags = splittedRule.filter(item => {
-            return item.startsWith('.') === false && item.startsWith('#') === false;
-          });
-
-          if (ruleTags.length === 0) {
-            return false;
-          }
-
-          const lastTags = ruleTags[ruleTags.length - 1];
-
-          return lastTags === tagName && lastTags === splittedRule[splittedRule.length - 1];
-        });
+        return !tagName ? [] : cssC.getRules().filter(rule => rule.selectorsToString() === tagName);
       };
 
       // Componente related rule

--- a/test/specs/style_manager/index.ts
+++ b/test/specs/style_manager/index.ts
@@ -73,7 +73,7 @@ describe('StyleManager', () => {
     });
 
     test('Add property to inexistent sector', () => {
-      expect(obj.addProperty('test', { property: 'test' })).toEqual(null);
+      expect(obj.addProperty('test', { property: 'test' })).toEqual(undefined);
     });
 
     test('Add property', () => {
@@ -182,6 +182,19 @@ describe('StyleManager', () => {
         expect(obj.getSelectedParents()).toEqual([rule2]);
       });
 
+      test('With ID + class, component first', () => {
+        sm.setComponentFirst(true);
+        const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
+        const [rule1, rule2] = cssc.addRules(`
+          .cls { color: red; }
+          #id-test { color: blue; }
+        `);
+        em.setSelected(cmp);
+        obj.__upSel();
+        expect(obj.getSelected()).toBe(rule2);
+        expect(obj.getSelectedParents()).toEqual([rule1]);
+      });
+
       test('With multiple classes, should both be in parents list', () => {
         const cmp = domc.addComponent('<div class="cls cls2"></div>');
         const [rule1, rule2] = cssc.addRules(`
@@ -220,19 +233,6 @@ describe('StyleManager', () => {
         expect(obj.getSelectedParents()).toEqual([rule3, rule2]);
       });
 
-      test('With ID + class, component first', () => {
-        sm.setComponentFirst(true);
-        const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
-        const [rule1, rule2] = cssc.addRules(`
-          .cls { color: red; }
-          #id-test { color: blue; }
-        `);
-        em.setSelected(cmp);
-        obj.__upSel();
-        expect(obj.getSelected()).toBe(rule2);
-        expect(obj.getSelectedParents()).toEqual([rule1]);
-      });
-
       test('With ID + class, multiple devices', () => {
         sm.setComponentFirst(true);
         const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
@@ -251,11 +251,15 @@ describe('StyleManager', () => {
 
       test('Mixed classes', () => {
         const cmp = domc.addComponent('<div class="cls1 cls2"></div>');
-        const [rule1, rule2] = cssc.addRules(`
+        const [a, b, rule1, rule2] = cssc.addRules(`
+          h1 { color: white; }
+          h1 .test { color: black; }
           .cls1 { color: red; }
           .cls1.cls2 { color: blue; }
           .cls2 { color: green; }
           .cls1.cls3 { color: green; }
+          h2 { color: white; }
+          h2 .test { color: black; }
         `);
         em.setSelected(cmp);
         obj.__upSel();

--- a/test/specs/style_manager/index.ts
+++ b/test/specs/style_manager/index.ts
@@ -220,6 +220,20 @@ describe('StyleManager', () => {
         expect(obj.getSelectedParents()).toEqual([rule2]);
       });
 
+      test('Should ignore rules with tagName in the selector path but the rule is not apply on the tagName', () => {
+        const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
+        const [rule1, rule2] = cssc.addRules(`
+          .cls { color: red; }
+          div { color: yellow; }
+          div .child { padding: 10px; }
+        `);
+        em.setSelected(cmp);
+        obj.__upSel();
+        // getSelectedParents should only have 1 rule as the third one is not applied on the div
+        expect(obj.getSelected()).toBe(rule1);
+        expect(obj.getSelectedParents()).toEqual([rule2]);
+      });
+
       test('With tagName + ID + class, class first, ID second', () => {
         const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
         const [rule1, rule2, rule3] = cssc.addRules(`

--- a/test/specs/style_manager/index.ts
+++ b/test/specs/style_manager/index.ts
@@ -234,6 +234,20 @@ describe('StyleManager', () => {
         expect(obj.getSelectedParents()).toEqual([rule2]);
       });
 
+      test('Should tagName rules if the selectors does not contain only the tagNale', () => {
+        const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
+        const [rule1, rule2] = cssc.addRules(`
+          .cls { color: red; }
+          div { color: yellow; }
+          .child div { padding: 10px; }
+        `);
+        em.setSelected(cmp);
+        obj.__upSel();
+        // getSelectedParents should only have 1 rule as the third one is not applied on the div
+        expect(obj.getSelected()).toBe(rule1);
+        expect(obj.getSelectedParents()).toEqual([rule2]);
+      });
+
       test('With tagName + ID + class, class first, ID second', () => {
         const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
         const [rule1, rule2, rule3] = cssc.addRules(`

--- a/test/specs/style_manager/index.ts
+++ b/test/specs/style_manager/index.ts
@@ -73,7 +73,7 @@ describe('StyleManager', () => {
     });
 
     test('Add property to inexistent sector', () => {
-      expect(obj.addProperty('test', { property: 'test' })).toEqual(undefined);
+      expect(obj.addProperty('test', { property: 'test' })).toEqual(null);
     });
 
     test('Add property', () => {
@@ -182,6 +182,44 @@ describe('StyleManager', () => {
         expect(obj.getSelectedParents()).toEqual([rule2]);
       });
 
+      test('With multiple classes, should both be in parents list', () => {
+        const cmp = domc.addComponent('<div class="cls cls2"></div>');
+        const [rule1, rule2] = cssc.addRules(`
+          .cls { color: red; }
+          .cls2 { color: blue; }
+        `);
+        em.setSelected(cmp);
+        obj.__upSel();
+        expect(obj.getSelected()).not.toBe(rule1);
+        expect(obj.getSelected()).not.toBe(rule2);
+        expect(obj.getSelectedParents()).toEqual([rule2, rule1]);
+      });
+
+      test('With tagName + class, class first', () => {
+        const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
+        const [rule1, rule2] = cssc.addRules(`
+          .cls { color: red; }
+          div { color: yellow; }
+        `);
+        em.setSelected(cmp);
+        obj.__upSel();
+        expect(obj.getSelected()).toBe(rule1);
+        expect(obj.getSelectedParents()).toEqual([rule2]);
+      });
+
+      test('With tagName + ID + class, class first, ID second', () => {
+        const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
+        const [rule1, rule2, rule3] = cssc.addRules(`
+          .cls { color: red; }
+          div { color: yellow; }
+          #id-test { color: blue; }
+        `);
+        em.setSelected(cmp);
+        obj.__upSel();
+        expect(obj.getSelected()).toBe(rule1);
+        expect(obj.getSelectedParents()).toEqual([rule3, rule2]);
+      });
+
       test('With ID + class, component first', () => {
         sm.setComponentFirst(true);
         const cmp = domc.addComponent('<div class="cls" id="id-test"></div>');
@@ -213,15 +251,11 @@ describe('StyleManager', () => {
 
       test('Mixed classes', () => {
         const cmp = domc.addComponent('<div class="cls1 cls2"></div>');
-        const [a, b, rule1, rule2] = cssc.addRules(`
-          h1 { color: white; }
-          h1 .test { color: black; }
+        const [rule1, rule2] = cssc.addRules(`
           .cls1 { color: red; }
           .cls1.cls2 { color: blue; }
           .cls2 { color: green; }
           .cls1.cls3 { color: green; }
-          h2 { color: white; }
-          h2 .test { color: black; }
         `);
         em.setSelected(cmp);
         obj.__upSel();


### PR DESCRIPTION
### Current behavior

The current behavior describe below can be tested on this JSFiddle : https://jsfiddle.net/728urdh3/

#### Context

I add a custom component (`sectionBlock`) that have styles by the `section` tag name and the private selector `ed-layout-div`.

```css
section {
  width: 940px;
  min-height: 50px;
  border: 1px dashed black;
}

.ed-layout-div {
  margin-top: 20px;
  margin-bottom: 30px;          
}
```

#### Step to reproduce

When you drop this component in the canvas and check it's style.

- You **do not see** `width` and `min-height` properties set on the section.
- You **see** the `margin-top` and the `margin-bottom` apply on the hidden selectors.

![Screenshot 2024-05-17 at 08 25 43](https://github.com/GrapesJS/grapesjs/assets/18048363/ddc6832c-6958-459f-b8a9-66fce9d76793)

Now when you add a class to the component :

- You **do not see anymore** the `margin-top` and the `margin-bottom` apply on the hidden selectors.

![Screenshot 2024-05-17 at 08 27 20](https://github.com/GrapesJS/grapesjs/assets/18048363/a5a337cf-99b4-466a-a321-3bd16f3ab988)

### Expected and new behavior

#### Context

The context is the same than the previous one

#### Step to reproduce

When you drop this component in the canvas and check it's style.

- You **see** `width` and `min-height` properties set on the section as parent rules
- You **see** `margin-top` and `margin-bottom` apply on the hidden selectors as parent rules

![Screenshot 2024-05-17 at 08 28 16](https://github.com/GrapesJS/grapesjs/assets/18048363/ade8a579-27fd-4892-8b9d-72c2ea97fd7b)

Now when you add a class to the component :

- You still **see** `width` and `min-height` properties set on the section as parent rules
- You still **see** `margin-top` and `margin-bottom` apply on the hidden selectors as parent rules

![Screenshot 2024-05-17 at 08 28 31](https://github.com/GrapesJS/grapesjs/assets/18048363/511e71a6-0f81-4006-8669-167b132fea2c)

### Why do I do that?

I think it's more comfortable to always see the style that is apply on the component to better understand why it is like it is. You still can override style but you always know which rule are applied to the component.

All tests passed and I add 3 new tests to test style apply on tag name and return style with multiple classes.

Do not hesitate if you need more information or if I have to update/fix something !

Have a great day!