### PR TITLE
Introduce HTML string document import

### DIFF
--- a/src/abstract/ModuleCategories.ts
+++ b/src/abstract/ModuleCategories.ts
@@ -1,9 +1,29 @@
 import { isArray, isString } from 'underscore';
 import { AddOptions, Collection } from '../common';
 import { normalizeKey } from '../utils/mixins';
+import EditorModel from '../editor/model/Editor';
 import Category, { CategoryProperties } from './ModuleCategory';
 
+type CategoryCollectionParams = ConstructorParameters<typeof Collection<Category>>;
+
+interface CategoryOptions {
+  events?: { update?: string };
+  em?: EditorModel;
+}
+
 export default class Categories extends Collection<Category> {
+  constructor(models?: CategoryCollectionParams[0], opts: CategoryOptions = {}) {
+    super(models, opts);
+    const { events, em } = opts;
+    const evUpdate = events?.update;
+    if (em) {
+      evUpdate &&
+        this.on('change', (category, options) =>
+          em.trigger(evUpdate, { category, changes: category.changedAttributes(), options })
+        );
+    }
+  }
+
   /** @ts-ignore */
   add(model: (CategoryProperties | Category)[] | CategoryProperties | Category, opts?: AddOptions) {
     const models = isArray(model) ? model : [model];

--- a/src/block_manager/index.ts
+++ b/src/block_manager/index.ts
@@ -66,7 +66,10 @@ export default class BlockManager extends ItemManagerModule<BlockManagerConfig, 
     // Global blocks collection
     this.blocks = this.all;
     this.blocksVisible = new Blocks(this.blocks.models, { em });
-    this.categories = new Categories();
+    this.categories = new Categories([], {
+      em,
+      events: { update: BlocksEvents.categoryUpdate },
+    });
 
     // Setup the sync between the global and public collections
     this.blocks.on('add', model => this.blocksVisible.add(model));

--- a/src/block_manager/types.ts
+++ b/src/block_manager/types.ts
@@ -55,6 +55,13 @@ export enum BlocksEvents {
   dragEnd = 'block:drag:stop',
 
   /**
+   * @event `block:category:update` Block category updated.
+   * @example
+   * editor.on('block:category:update', ({ category, changes }) => { ... });
+   */
+  categoryUpdate = 'block:category:update',
+
+  /**
    * @event `block:custom` Event to use in case of [custom Block Manager UI](https://grapesjs.com/docs/modules/Blocks.html#customization).
    * @example
    * editor.on('block:custom', ({ container, blocks, ... }) => { ... });

--- a/src/canvas/view/FrameView.ts
+++ b/src/canvas/view/FrameView.ts
@@ -3,6 +3,8 @@ import { ModuleView } from '../../abstract';
 import { BoxRect, ObjectAny } from '../../common';
 import CssRulesView from '../../css_composer/view/CssRulesView';
 import ComponentWrapperView from '../../dom_components/view/ComponentWrapperView';
+import ComponentView from '../../dom_components/view/ComponentView';
+import { type as typeHead } from '../../dom_components/model/ComponentHead';
 import Droppable from '../../utils/Droppable';
 import {
   append,
@@ -40,6 +42,7 @@ export default class FrameView extends ModuleView<Frame, HTMLIFrameElement> {
   private jsContainer?: HTMLElement;
   private tools: { [key: string]: HTMLElement } = {};
   private wrapper?: ComponentWrapperView;
+  private headView?: ComponentView;
   private frameWrapView?: FrameWrapView;
 
   constructor(model: Frame, view?: FrameWrapView) {
@@ -333,6 +336,7 @@ export default class FrameView extends ModuleView<Frame, HTMLIFrameElement> {
       evOpts.window = this.getWindow();
       em?.trigger(`${evLoad}:before`, evOpts); // deprecated
       em?.trigger(CanvasEvents.frameLoad, evOpts);
+      this.renderHead();
       appendScript([...canvas.get('scripts')]);
     };
   }
@@ -366,6 +370,20 @@ export default class FrameView extends ModuleView<Frame, HTMLIFrameElement> {
       el?.parentNode?.removeChild(el);
     });
     appendVNodes(head, toAdd);
+  }
+
+  renderHead() {
+    const { model, em } = this;
+    const { root } = model;
+    const HeadView = em.Components.getType(typeHead)!.view;
+    this.headView = new HeadView({
+      el: this.getHead(),
+      model: root.head,
+      config: {
+        ...root.config,
+        frameView: this,
+      },
+    }).render();
   }
 
   renderBody() {

--- a/src/code_manager/model/HtmlGenerator.ts
+++ b/src/code_manager/model/HtmlGenerator.ts
@@ -1,19 +1,14 @@
 import { Model } from '../../common';
 import Component from '../../dom_components/model/Component';
+import { ToHTMLOptions } from '../../dom_components/model/types';
 import EditorModel from '../../editor/model/Editor';
 
-export type HTMLGeneratorBuildOptions = {
+export interface HTMLGeneratorBuildOptions extends ToHTMLOptions {
   /**
    * Remove unnecessary IDs (eg. those created automatically).
    */
   cleanId?: boolean;
-
-  /**
-   * You can pass an object of custom attributes to replace with the current ones
-   * or you can even pass a function to generate attributes dynamically.
-   */
-  attributes?: Record<string, any> | ((component: Component, attr: Record<string, any>) => Record<string, any>);
-};
+}
 
 export default class HTMLGenerator extends Model {
   build(model: Component, opts: HTMLGeneratorBuildOptions & { em?: EditorModel } = {}) {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -27,7 +27,7 @@ export type Nullable = undefined | null | false;
 
 export interface OptionAsDocument {
   /**
-   * Treat the HTML string as document (option valid on the root component, eg. will include `<head>`, `<html>`, etc.).
+   * Treat the HTML string as document (option valid on the root component, eg. will include doctype, html, head, etc.).
    */
   asDocument?: boolean;
 }

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -25,6 +25,13 @@ export type ObjectStrings = Record<string, string>;
 
 export type Nullable = undefined | null | false;
 
+export interface OptionAsDocument {
+  /**
+   * Treat the HTML string as document (option valid on the root component, eg. will include `<head>`, `<html>`, etc.).
+   */
+  asDocument?: boolean;
+}
+
 // https://github.com/microsoft/TypeScript/issues/29729#issuecomment-1483854699
 export type LiteralUnion<T, U> = T | (U & NOOP);
 

--- a/src/dom_components/index.ts
+++ b/src/dom_components/index.ts
@@ -101,6 +101,7 @@ import ComponentVideoView from './view/ComponentVideoView';
 import ComponentView, { IComponentView } from './view/ComponentView';
 import ComponentWrapperView from './view/ComponentWrapperView';
 import ComponentsView from './view/ComponentsView';
+import ComponentHead, { type as typeHead } from './model/ComponentHead';
 
 export type ComponentEvent =
   | 'component:create'
@@ -259,6 +260,11 @@ export default class ComponentManager extends ItemManagerModule<DomComponentsCon
       id: 'wrapper',
       model: ComponentWrapper,
       view: ComponentWrapperView,
+    },
+    {
+      id: typeHead,
+      model: ComponentHead,
+      view: ComponentView,
     },
     {
       id: 'default',

--- a/src/dom_components/index.ts
+++ b/src/dom_components/index.ts
@@ -252,9 +252,9 @@ export default class ComponentManager extends ItemManagerModule<DomComponentsCon
       view: ComponentTextNodeView,
     },
     {
-      id: 'text',
-      model: ComponentText,
-      view: ComponentTextView,
+      id: typeHead,
+      model: ComponentHead,
+      view: ComponentView,
     },
     {
       id: 'wrapper',
@@ -262,9 +262,9 @@ export default class ComponentManager extends ItemManagerModule<DomComponentsCon
       view: ComponentWrapperView,
     },
     {
-      id: typeHead,
-      model: ComponentHead,
-      view: ComponentView,
+      id: 'text',
+      model: ComponentText,
+      view: ComponentTextView,
     },
     {
       id: 'default',

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -20,6 +20,7 @@ import Selectors from '../../selector_manager/model/Selectors';
 import Traits from '../../trait_manager/model/Traits';
 import EditorModel from '../../editor/model/Editor';
 import {
+  AddComponentsOption,
   ComponentAdd,
   ComponentDefinition,
   ComponentDefinitionDefined,
@@ -1149,7 +1150,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
    */
   components<T extends ComponentAdd | undefined>(
     components?: T,
-    opts: any = {}
+    opts: AddComponentsOption = {}
   ): undefined extends T ? Components : Component[] {
     const coll = this.get('components')!;
 

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -2039,7 +2039,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
     return result(this.prototype, 'defaults');
   }
 
-  static isComponent(el: HTMLElement): ComponentDefinitionDefined | boolean | undefined {
+  static isComponent(el: HTMLElement, opts?: any): ComponentDefinitionDefined | boolean | undefined {
     return { tagName: toLowerCase(el.tagName) };
   }
 

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -164,6 +164,10 @@ export default class Component extends StyleableModel<ComponentProperties> {
     };
   }
 
+  get tagName() {
+    return this.get('tagName')!;
+  }
+
   get classes() {
     return this.get('classes')!;
   }

--- a/src/dom_components/model/ComponentHead.ts
+++ b/src/dom_components/model/ComponentHead.ts
@@ -1,7 +1,9 @@
 import Component from './Component';
 import { toLowerCase } from '../../utils/mixins';
+import { DraggableDroppableFn } from './types';
 
 export const type = 'head';
+const droppable = ['title', 'style', 'base', 'link', 'meta', 'script', 'noscript'];
 
 export default class ComponentHead extends Component {
   get defaults() {
@@ -11,7 +13,7 @@ export default class ComponentHead extends Component {
       type,
       tagName: type,
       draggable: false,
-      droppable: ['title', 'style', 'base', 'link', 'meta', 'script', 'noscript'],
+      droppable: (({ tagName }) => !tagName || droppable.includes(toLowerCase(tagName))) as DraggableDroppableFn,
     };
   }
 

--- a/src/dom_components/model/ComponentHead.ts
+++ b/src/dom_components/model/ComponentHead.ts
@@ -1,7 +1,7 @@
 import Component from './Component';
 import { toLowerCase } from '../../utils/mixins';
 
-const type = 'head';
+export const type = 'head';
 
 export default class ComponentHead extends Component {
   get defaults() {

--- a/src/dom_components/model/ComponentHead.ts
+++ b/src/dom_components/model/ComponentHead.ts
@@ -13,6 +13,7 @@ export default class ComponentHead extends Component {
       type,
       tagName: type,
       draggable: false,
+      highlightable: false,
       droppable: (({ tagName }) => !tagName || droppable.includes(toLowerCase(tagName))) as DraggableDroppableFn,
     };
   }

--- a/src/dom_components/model/ComponentHead.ts
+++ b/src/dom_components/model/ComponentHead.ts
@@ -1,0 +1,21 @@
+import Component from './Component';
+import { toLowerCase } from '../../utils/mixins';
+
+const type = 'head';
+
+export default class ComponentHead extends Component {
+  get defaults() {
+    return {
+      // @ts-ignore
+      ...super.defaults,
+      type,
+      tagName: type,
+      draggable: false,
+      droppable: ['title', 'style', 'base', 'link', 'meta', 'script', 'noscript'],
+    };
+  }
+
+  static isComponent(el: HTMLElement) {
+    return toLowerCase(el.tagName) === type;
+  }
+}

--- a/src/dom_components/model/ComponentWrapper.ts
+++ b/src/dom_components/model/ComponentWrapper.ts
@@ -1,4 +1,5 @@
 import Component from './Component';
+import ComponentHead, { type as typeHead } from './ComponentHead';
 
 export default class ComponentWrapper extends Component {
   get defaults() {
@@ -11,6 +12,7 @@ export default class ComponentWrapper extends Component {
       draggable: false,
       components: [],
       traits: [],
+      head: null,
       stylable: [
         'background',
         'background-color',
@@ -21,6 +23,21 @@ export default class ComponentWrapper extends Component {
         'background-size',
       ],
     };
+  }
+
+  constructor(...args: ConstructorParameters<typeof Component>) {
+    super(...args);
+    const opts = args[1];
+    const CmpHead = opts?.em?.Components.getType(typeHead)?.model;
+    if (CmpHead) {
+      this.set({
+        head: new CmpHead({}, opts),
+      });
+    }
+  }
+
+  get head(): ComponentHead {
+    return this.get('head');
   }
 
   __postAdd() {

--- a/src/dom_components/model/ComponentWrapper.ts
+++ b/src/dom_components/model/ComponentWrapper.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from 'underscore';
 import { attrToString } from '../../utils/dom';
 import Component from './Component';
 import ComponentHead, { type as typeHead } from './ComponentHead';
@@ -52,14 +53,14 @@ export default class ComponentWrapper extends Component {
   }
 
   toHTML(opts: ToHTMLOptions = {}) {
-    const { asDocument } = opts;
-    const { head, docEl } = this;
     const { doctype = '' } = this.attributes;
+    const asDoc = !isUndefined(opts.asDocument) ? opts.asDocument : !!doctype;
+    const { head, docEl } = this;
     const body = super.toHTML(opts);
-    const headStr = (asDocument && head?.toHTML(opts)) || '';
-    const docElAttr = (asDocument && attrToString(docEl?.getAttrToHTML())) || '';
+    const headStr = (asDoc && head?.toHTML(opts)) || '';
+    const docElAttr = (asDoc && attrToString(docEl?.getAttrToHTML())) || '';
     const docElAttrStr = docElAttr ? ` ${docElAttr}` : '';
-    return asDocument ? `${doctype}<html${docElAttrStr}>${headStr}${body}</html>` : body;
+    return asDoc ? `${doctype}<html${docElAttrStr}>${headStr}${body}</html>` : body;
   }
 
   __postAdd() {

--- a/src/dom_components/model/ComponentWrapper.ts
+++ b/src/dom_components/model/ComponentWrapper.ts
@@ -37,10 +37,13 @@ export default class ComponentWrapper extends Component {
     const CmpHead = cmp?.getType(typeHead)?.model;
     const CmpDef = cmp?.getType('default').model;
     if (CmpHead) {
-      this.set({
-        head: new CmpHead({}, opts),
-        docEl: new CmpDef({ tagName: 'html' }, opts),
-      });
+      this.set(
+        {
+          head: new CmpHead({}, opts),
+          docEl: new CmpDef({ tagName: 'html' }, opts),
+        },
+        { silent: true }
+      );
     }
   }
 

--- a/src/dom_components/model/ComponentWrapper.ts
+++ b/src/dom_components/model/ComponentWrapper.ts
@@ -55,8 +55,12 @@ export default class ComponentWrapper extends Component {
     return this.get('docEl');
   }
 
+  get doctype(): string {
+    return this.attributes.doctype || '';
+  }
+
   toHTML(opts: ToHTMLOptions = {}) {
-    const { doctype = '' } = this.attributes;
+    const { doctype } = this;
     const asDoc = !isUndefined(opts.asDocument) ? opts.asDocument : !!doctype;
     const { head, docEl } = this;
     const body = super.toHTML(opts);

--- a/src/dom_components/model/ComponentWrapper.ts
+++ b/src/dom_components/model/ComponentWrapper.ts
@@ -13,7 +13,6 @@ export default class ComponentWrapper extends Component {
       draggable: false,
       components: [],
       traits: [],
-      // In case we might need the doctype as component https://stackoverflow.com/a/10162353
       doctype: '',
       head: null,
       stylable: [

--- a/src/dom_components/model/ComponentWrapper.ts
+++ b/src/dom_components/model/ComponentWrapper.ts
@@ -1,5 +1,6 @@
 import Component from './Component';
 import ComponentHead, { type as typeHead } from './ComponentHead';
+import { ToHTMLOptions } from './types';
 
 export default class ComponentWrapper extends Component {
   get defaults() {
@@ -12,6 +13,8 @@ export default class ComponentWrapper extends Component {
       draggable: false,
       components: [],
       traits: [],
+      // In case we might need the doctype as component https://stackoverflow.com/a/10162353
+      doctype: '',
       head: null,
       stylable: [
         'background',
@@ -38,6 +41,14 @@ export default class ComponentWrapper extends Component {
 
   get head(): ComponentHead {
     return this.get('head');
+  }
+
+  toHTML(opts: ToHTMLOptions = {}) {
+    const { asDocument } = opts;
+    const { doctype = '' } = this.attributes;
+    const body = super.toHTML(opts);
+    const head = (asDocument && this.head?.toHTML(opts)) || '';
+    return asDocument ? `${doctype}${head}${body}` : body;
   }
 
   __postAdd() {

--- a/src/dom_components/model/Components.ts
+++ b/src/dom_components/model/Components.ts
@@ -5,7 +5,7 @@ import { DomComponentsConfig } from '../config/config';
 import EditorModel from '../../editor/model/Editor';
 import ComponentManager from '..';
 import CssRule from '../../css_composer/model/CssRule';
-import { ComponentAdd, ComponentProperties } from './types';
+import { ComponentAdd, ComponentDefinitionDefined, ComponentProperties } from './types';
 import ComponentText from './ComponentText';
 import ComponentWrapper from './ComponentWrapper';
 
@@ -238,10 +238,12 @@ Component> {
 
     if (asDocument) {
       const root = parent as ComponentWrapper;
-      components = (parsed.html as any).components;
+      const { components: bodyCmps, ...restBody } = (parsed.html as ComponentDefinitionDefined) || {};
       const { components: headCmps, ...restHead } = parsed.head || {};
+      components = bodyCmps!;
+      root.set(restBody as any, opt);
       root.head.set(restHead as any, opt);
-      root.head.components(headCmps);
+      root.head.components(headCmps, opt);
       root.docEl.set(parsed.root as any, opt);
       root.set({ doctype: parsed.doctype });
     }

--- a/src/dom_components/model/Components.ts
+++ b/src/dom_components/model/Components.ts
@@ -239,7 +239,9 @@ Component> {
     if (asDocument) {
       const root = parent as ComponentWrapper;
       components = (parsed.html as any).components;
-      root.head.set(parsed.head as any, opt);
+      const { components: headCmps, ...restHead } = parsed.head || {};
+      root.head.set(restHead as any, opt);
+      root.head.components(headCmps);
       root.docEl.set(parsed.root as any, opt);
       root.set({ doctype: parsed.doctype });
     }

--- a/src/dom_components/model/types.ts
+++ b/src/dom_components/model/types.ts
@@ -1,5 +1,5 @@
 import Frame from '../../canvas/model/Frame';
-import { Nullable } from '../../common';
+import { Nullable, OptionAsDocument } from '../../common';
 import EditorModel from '../../editor/model/Editor';
 import Selectors from '../../selector_manager/model/Selectors';
 import { TraitProperties } from '../../trait_manager/types';
@@ -264,7 +264,7 @@ type ComponentAddType = Component | ComponentDefinition | ComponentDefinitionDef
 
 export type ComponentAdd = ComponentAddType | ComponentAddType[];
 
-export interface ToHTMLOptions {
+export interface ToHTMLOptions extends OptionAsDocument {
   /**
    * Custom tagName.
    */
@@ -279,11 +279,6 @@ export interface ToHTMLOptions {
    * In case the attribute value contains a `"` char, instead of escaping it (`attr="value &quot;"`), the attribute will be quoted using single quotes (`attr='value "'`).
    */
   altQuoteAttr?: boolean;
-
-  /**
-   * Return the HTML string as document (option valid on the root component, eg. will include the <head>).
-   */
-  asDocument?: boolean;
 
   /**
    * You can pass an object of custom attributes to replace with the current ones

--- a/src/dom_components/model/types.ts
+++ b/src/dom_components/model/types.ts
@@ -1,5 +1,5 @@
 import Frame from '../../canvas/model/Frame';
-import { Nullable, OptionAsDocument } from '../../common';
+import { AddOptions, Nullable, OptionAsDocument } from '../../common';
 import EditorModel from '../../editor/model/Editor';
 import Selectors from '../../selector_manager/model/Selectors';
 import { TraitProperties } from '../../trait_manager/types';
@@ -14,6 +14,8 @@ import { ToolbarButtonProps } from './ToolbarButton';
 export type DragMode = 'translate' | 'absolute' | '';
 
 export type DraggableDroppableFn = (source: Component, target: Component, index?: number) => boolean | void;
+
+export interface AddComponentsOption extends AddOptions, OptionAsDocument {}
 
 export interface ComponentStackItem {
   id: string;

--- a/src/dom_components/model/types.ts
+++ b/src/dom_components/model/types.ts
@@ -264,7 +264,7 @@ type ComponentAddType = Component | ComponentDefinition | ComponentDefinitionDef
 
 export type ComponentAdd = ComponentAddType | ComponentAddType[];
 
-export type ToHTMLOptions = {
+export interface ToHTMLOptions {
   /**
    * Custom tagName.
    */
@@ -281,11 +281,16 @@ export type ToHTMLOptions = {
   altQuoteAttr?: boolean;
 
   /**
+   * Return the HTML string as document (option valid on the root component, eg. will include the <head>).
+   */
+  asDocument?: boolean;
+
+  /**
    * You can pass an object of custom attributes to replace with the current ones
    * or you can even pass a function to generate attributes dynamically.
    */
   attributes?: Record<string, any> | ((component: Component, attr: Record<string, any>) => Record<string, any>);
-};
+}
 
 export interface ComponentOptions {
   em?: EditorModel;

--- a/src/parser/config/config.ts
+++ b/src/parser/config/config.ts
@@ -23,6 +23,7 @@ export interface HTMLParseResult {
 
 export interface ParseNodeOptions extends HTMLParserOptions {
   inSvg?: boolean;
+  skipChildren?: boolean;
 }
 
 export interface HTMLParserOptions {

--- a/src/parser/config/config.ts
+++ b/src/parser/config/config.ts
@@ -1,3 +1,5 @@
+import { CssRuleJSON } from '../../css_composer/model/CssRule';
+import { ComponentDefinitionDefined } from '../../dom_components/model/types';
 import Editor from '../../editor';
 
 export interface ParsedCssRule {
@@ -11,6 +13,18 @@ export type CustomParserCss = (input: string, editor: Editor) => ParsedCssRule[]
 
 export type CustomParserHtml = (input: string, options: HTMLParserOptions) => HTMLElement;
 
+export interface HTMLParseResult {
+  html: ComponentDefinitionDefined | ComponentDefinitionDefined[];
+  css?: CssRuleJSON[];
+  doctype?: string;
+  root?: ComponentDefinitionDefined;
+  head?: ComponentDefinitionDefined;
+}
+
+export interface ParseNodeOptions extends HTMLParserOptions {
+  inSvg?: boolean;
+}
+
 export interface HTMLParserOptions {
   /**
    * DOMParser mime type.
@@ -19,6 +33,12 @@ export interface HTMLParserOptions {
    * @default 'text/html'
    */
   htmlType?: DOMParserSupportedType;
+
+  /**
+   * Parse the string as HTML document. The result will include additional data (eg. doctype, head, etc.)
+   * @default false
+   */
+  asDocument?: boolean;
 
   /**
    * Allow <script> tags.

--- a/src/parser/config/config.ts
+++ b/src/parser/config/config.ts
@@ -1,3 +1,4 @@
+import { OptionAsDocument } from '../../common';
 import { CssRuleJSON } from '../../css_composer/model/CssRule';
 import { ComponentDefinitionDefined } from '../../dom_components/model/types';
 import Editor from '../../editor';
@@ -26,7 +27,7 @@ export interface ParseNodeOptions extends HTMLParserOptions {
   skipChildren?: boolean;
 }
 
-export interface HTMLParserOptions {
+export interface HTMLParserOptions extends OptionAsDocument {
   /**
    * DOMParser mime type.
    * If you use the `text/html` parser, it will fix the invalid syntax automatically.
@@ -34,12 +35,6 @@ export interface HTMLParserOptions {
    * @default 'text/html'
    */
   htmlType?: DOMParserSupportedType;
-
-  /**
-   * Parse the string as HTML document. The result will include additional data (eg. doctype, head, etc.)
-   * @default false
-   */
-  asDocument?: boolean;
 
   /**
    * Allow <script> tags.

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -69,7 +69,7 @@ export default class ParserModule extends Module<ParserConfig & { name?: string 
    */
   parseHtml(input: string, options: HTMLParserOptions = {}) {
     const { em, parserHtml } = this;
-    parserHtml.compTypes = (em.Components.getTypes() || {}) as any;
+    parserHtml.compTypes = em.Components.getTypes() || [];
     return parserHtml.parse(input, this.parserCss, options);
   }
 

--- a/src/parser/model/BrowserParserHtml.ts
+++ b/src/parser/model/BrowserParserHtml.ts
@@ -13,6 +13,8 @@ export default (str: string, config: HTMLParserOptions = {}) => {
   let res: HTMLElement;
 
   if (toHTML) {
+    if (config.asDocument) return doc;
+
     // Replicate the old parser in order to avoid breaking changes
     const { head, body } = doc;
     // Move all scripts at the bottom of the page

--- a/src/parser/model/ParserHtml.ts
+++ b/src/parser/model/ParserHtml.ts
@@ -363,6 +363,7 @@ const ParserHtml = (em?: EditorModel, config: ParserConfig & { returnArray?: boo
       let resHtml: HTMLParseResult['html'] = [];
 
       if (asDocument) {
+        console.log(this.detectNode(docEl.head, cf));
         res.head = this.parseNode(docEl.head, cf);
         res.root = this.parseNodeAttr(root);
         resHtml = this.parseNode(docEl.body, cf);

--- a/src/parser/model/ParserHtml.ts
+++ b/src/parser/model/ParserHtml.ts
@@ -363,7 +363,6 @@ const ParserHtml = (em?: EditorModel, config: ParserConfig & { returnArray?: boo
       let resHtml: HTMLParseResult['html'] = [];
 
       if (asDocument) {
-        console.log(this.detectNode(docEl.head, cf));
         res.head = this.parseNode(docEl.head, cf);
         res.root = this.parseNodeAttr(root);
         resHtml = this.parseNode(docEl.body, cf);

--- a/src/trait_manager/model/Traits.ts
+++ b/src/trait_manager/model/Traits.ts
@@ -5,7 +5,7 @@ import Categories from '../../abstract/ModuleCategories';
 import { AddOptions } from '../../common';
 import Component from '../../dom_components/model/Component';
 import EditorModel from '../../editor/model/Editor';
-import { TraitProperties } from '../types';
+import TraitsEvents, { TraitProperties } from '../types';
 import Trait from './Trait';
 import TraitFactory from './TraitFactory';
 
@@ -17,7 +17,12 @@ export default class Traits extends CollectionWithCategories<Trait> {
 
   constructor(coll: TraitProperties[], options: { em: EditorModel }) {
     super(coll);
-    this.em = options.em;
+    const { em } = options;
+    this.em = em;
+    this.categories = new Categories([], {
+      em,
+      events: { update: TraitsEvents.categoryUpdate },
+    });
     this.on('add', this.handleAdd);
     this.on('reset', this.handleReset);
     const tm = this.module;

--- a/src/trait_manager/types.ts
+++ b/src/trait_manager/types.ts
@@ -189,6 +189,13 @@ export enum TraitsEvents {
   value = 'trait:value',
 
   /**
+   * @event `trait:category:update` Trait category updated.
+   * @example
+   * editor.on('trait:category:update', ({ category, changes }) => { ... });
+   */
+  categoryUpdate = 'trait:category:update',
+
+  /**
    * @event `trait:custom` Event to use in case of [custom Trait Manager UI](https://grapesjs.com/docs/modules/Traits.html#custom-trait-manager).
    * @example
    * editor.on('trait:custom', ({ container }) => { ... });

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -214,6 +214,12 @@ export const doctypeToString = (dt?: DocumentType | null) => {
   return `<!DOCTYPE ${name}${pubId}${sysId}>`;
 };
 
+export const attrToString = (attrs: ObjectAny = {}) => {
+  const res: string[] = [];
+  each(attrs, (value, key) => res.push(`${key}="${value}"`));
+  return res.join(' ');
+};
+
 export const on = <E extends Event = Event>(
   el: EventTarget | EventTarget[],
   ev: string,

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -205,6 +205,15 @@ export const hasCtrlKey = (ev: WheelEvent) => ev.ctrlKey;
 
 export const hasModifierKey = (ev: WheelEvent) => hasCtrlKey(ev) || ev.metaKey;
 
+// Ref: https://stackoverflow.com/a/10162353
+export const doctypeToString = (dt?: DocumentType | null) => {
+  if (!dt) return '';
+  const { name, publicId, systemId } = dt;
+  const pubId = publicId ? ` PUBLIC "${publicId}"` : '';
+  const sysId = !publicId && systemId ? ` SYSTEM "${systemId}"` : '';
+  return `<!DOCTYPE ${name}${pubId}${sysId}>`;
+};
+
 export const on = <E extends Event = Event>(
   el: EventTarget | EventTarget[],
   ev: string,

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,0 +1,2 @@
+// DocEl + Head + Wrapper
+export const DEFAULT_CMPS = 3;

--- a/test/specs/dom_components/index.ts
+++ b/test/specs/dom_components/index.ts
@@ -3,6 +3,7 @@ import EditorModel from '../../../src/editor/model/Editor';
 import Editor from '../../../src/editor';
 import utils from './../../test_utils.js';
 import { Component } from '../../../src';
+import ComponentWrapper from '../../../src/dom_components/model/ComponentWrapper';
 
 describe('DOM Components', () => {
   describe('Main', () => {
@@ -309,6 +310,88 @@ describe('DOM Components', () => {
         expect(obj.getComponents().length).toBe(2);
         expect(em.Css.getAll().length).toBe(1);
         expect(rule.getStyle()).toEqual(newStyle);
+      });
+    });
+  });
+
+  describe('Rendered components', () => {
+    let editor: Editor;
+    let em: EditorModel;
+    let fxt: HTMLElement;
+    let root: ComponentWrapper;
+
+    beforeEach(done => {
+      fxt = document.createElement('div');
+      document.body.appendChild(fxt);
+      editor = new Editor({
+        el: fxt,
+        avoidInlineStyle: true,
+        storageManager: false,
+      });
+      em = editor.getModel();
+      fxt.appendChild(em.Canvas.render());
+      em.loadOnStart();
+      editor.on('change:ready', () => {
+        root = editor.Components.getWrapper()!;
+        done();
+      });
+    });
+
+    afterEach(() => {
+      editor.destroy();
+    });
+
+    describe('render components with asDocument', () => {
+      const docHtml = `
+        <!DOCTYPE html>
+        <html lang="en" class="cls-html" data-gjs-htmlp="true">
+          <head class="cls-head" data-gjs-headp="true">
+            <meta charset="utf-8">
+            <title>Test</title>
+            <link rel="stylesheet" href="/noop.css">
+            <!-- comment -->
+          </head>
+          <body class="cls-body" data-gjs-bodyp="true">
+            <h1>H1</h1>
+          </body>
+        </html>
+      `;
+
+      test('initial setup', () => {
+        expect(root.head.components().length).toBe(0);
+        expect(root.get('doctype')).toBe('');
+      });
+
+      test('import HTML document without option', () => {
+        root.components(docHtml);
+        expect(root.head.components().length).toBe(0);
+        expect(root.get('doctype')).toBe('');
+      });
+
+      test('import HTML document with asDocument', () => {
+        root.components(docHtml, { asDocument: true });
+        const { head, docEl } = root;
+        expect(head.components().length).toBe(4);
+        expect(head.get('headp')).toBe(true);
+        expect(docEl.get('htmlp')).toBe(true);
+        expect(root.get('bodyp')).toBe(true);
+        expect(root.get('doctype')).toBe('<!DOCTYPE html>');
+
+        const outputHtml = `
+          <!DOCTYPE html>
+          <html lang="en" class="cls-html">
+            <head class="cls-head">
+              <meta charset="utf-8"/>
+              <title>Test</title>
+              <link rel="stylesheet" href="/noop.css"/>
+              <!-- comment -->
+            </head>
+            <body class="cls-body">
+              <h1>H1</h1>
+            </body>
+          </html>
+          `.replace(/>\s+|\s+</g, m => m.trim());
+        expect(root.toHTML()).toBe(outputHtml);
       });
     });
   });

--- a/test/specs/dom_components/index.ts
+++ b/test/specs/dom_components/index.ts
@@ -263,7 +263,7 @@ describe('DOM Components', () => {
         expect(rule.toCSS()).toEqual(css);
 
         done();
-      }, 10);
+      }, 20);
     });
 
     describe('Custom components with styles', () => {

--- a/test/specs/dom_components/index.ts
+++ b/test/specs/dom_components/index.ts
@@ -1,4 +1,3 @@
-import DomComponents from '../../../src/dom_components';
 import Components from '../../../src/dom_components/model/Components';
 import EditorModel from '../../../src/editor/model/Editor';
 import Editor from '../../../src/editor';
@@ -8,7 +7,7 @@ import { Component } from '../../../src';
 describe('DOM Components', () => {
   describe('Main', () => {
     var em: EditorModel;
-    var obj: DomComponents;
+    var obj: EditorModel['Components'];
     var config: any;
     var storagMock = utils.storageMock();
     var editorModel = {
@@ -61,10 +60,6 @@ describe('DOM Components', () => {
 
     afterEach(() => {
       em.destroy();
-    });
-
-    test('Object exists', () => {
-      expect(DomComponents).toBeTruthy();
     });
 
     test.skip('Store and load data', () => {
@@ -147,7 +142,6 @@ describe('DOM Components', () => {
     });
 
     test('Add new component type with simple model', () => {
-      obj = em.get('DomComponents');
       const id = 'test-type';
       const testProp = 'testValue';
       const initialTypes = obj.componentTypes.length;
@@ -166,7 +160,6 @@ describe('DOM Components', () => {
     });
 
     test('Add new component type with custom isComponent', () => {
-      obj = em.get('DomComponents');
       const id = 'test-type';
       const testProp = 'testValue';
       obj.addType(id, {
@@ -182,7 +175,6 @@ describe('DOM Components', () => {
     });
 
     test('Extend component type with custom model and view', () => {
-      obj = em.get('DomComponents');
       const id = 'image';
       const testProp = 'testValue';
       const initialTypes = obj.getTypes().length;
@@ -207,7 +199,6 @@ describe('DOM Components', () => {
     });
 
     test('Add new component type by extending another one, without isComponent', () => {
-      obj = em.get('DomComponents');
       const id = 'test-type';
       const testProp = 'testValue';
       obj.addType(id, {
@@ -228,7 +219,6 @@ describe('DOM Components', () => {
     });
 
     test('Add new component type by extending another one, with custom isComponent', () => {
-      obj = em.get('DomComponents');
       const id = 'test-type';
       const testProp = 'testValue';
       obj.addType(id, {

--- a/test/specs/dom_components/index.ts
+++ b/test/specs/dom_components/index.ts
@@ -375,7 +375,7 @@ describe('DOM Components', () => {
         expect(head.get('headp')).toBe(true);
         expect(docEl.get('htmlp')).toBe(true);
         expect(root.get('bodyp')).toBe(true);
-        expect(root.get('doctype')).toBe('<!DOCTYPE html>');
+        expect(root.doctype).toBe('<!DOCTYPE html>');
 
         const outputHtml = `
           <!DOCTYPE html>

--- a/test/specs/dom_components/model/Component.ts
+++ b/test/specs/dom_components/model/Component.ts
@@ -703,7 +703,8 @@ describe('Components', () => {
     const added = dcomp.addComponent(block) as Component;
     const addComps = added.components();
     // Let's check if everthing is working as expected
-    expect(Object.keys(dcomp.componentsById).length).toBe(3); // + 1 wrapper
+    // 2 test components + 1 wrapper + 1 head + 1 docEl
+    expect(Object.keys(dcomp.componentsById).length).toBe(5);
     expect(added.getId()).toBe(id);
     expect(addComps.at(0).getId()).toBe(idB);
     const cc = em.get('CssComposer');

--- a/test/specs/editor/index.ts
+++ b/test/specs/editor/index.ts
@@ -1,7 +1,7 @@
 import Editor from '../../../src/editor';
+import { DEFAULT_CMPS } from '../../common';
 
 const { keys } = Object;
-const initComps = 1;
 
 describe('Editor', () => {
   let editor: Editor;
@@ -24,7 +24,7 @@ describe('Editor', () => {
     const all = editor.Components.allById();
     const allKeys = keys(all);
     // By default 1 wrapper components is created
-    expect(allKeys.length).toBe(initComps);
+    expect(allKeys.length).toBe(DEFAULT_CMPS);
     expect(all[allKeys[0]].get('type')).toBe('wrapper');
   });
 
@@ -50,7 +50,7 @@ describe('Editor', () => {
     const all = editor.Components.allById();
     const wrapper = editor.getWrapper()!;
     wrapper.append('<div>Component</div>'); // Div component + textnode
-    expect(keys(all).length).toBe(2 + initComps);
+    expect(keys(all).length).toBe(2 + DEFAULT_CMPS);
   });
 
   test('Components are correctly tracked on add and remove', () => {
@@ -60,16 +60,16 @@ describe('Editor', () => {
         <div>Component 1</div>
         <div></div>
     `);
-    expect(keys(all).length).toBe(3 + initComps);
+    expect(keys(all).length).toBe(3 + DEFAULT_CMPS);
     const secComp = added[1];
     secComp.append(`
         <div>Component 2</div>
         <div>Component 3</div>
     `);
-    expect(keys(all).length).toBe(7 + initComps);
+    expect(keys(all).length).toBe(7 + DEFAULT_CMPS);
     wrapper.empty();
     expect(wrapper.components().length).toBe(0);
-    expect(keys(all).length).toBe(initComps);
+    expect(keys(all).length).toBe(DEFAULT_CMPS);
   });
 
   test('Components are correctly tracked with UndoManager', () => {
@@ -82,9 +82,9 @@ describe('Editor', () => {
     expect(umStack.length).toBe(1);
     wrapper.empty();
     expect(umStack.length).toBe(2);
-    expect(keys(all).length).toBe(initComps);
+    expect(keys(all).length).toBe(DEFAULT_CMPS);
     um.undo(false);
-    expect(keys(all).length).toBe(2 + initComps);
+    expect(keys(all).length).toBe(2 + DEFAULT_CMPS);
   });
 
   test('Components are correctly tracked with UndoManager and mutiple operations', () => {
@@ -98,13 +98,13 @@ describe('Editor', () => {
         <div>Component 2</div>
     </div>`);
     expect(umStack.length).toBe(1); // UM counts first children
-    expect(keys(all).length).toBe(5 + initComps);
+    expect(keys(all).length).toBe(5 + DEFAULT_CMPS);
     wrapper.components().at(0).components().at(0).remove(); // Remove 1 component
 
     expect(umStack.length).toBe(2);
-    expect(keys(all).length).toBe(3 + initComps);
+    expect(keys(all).length).toBe(3 + DEFAULT_CMPS);
     wrapper.empty();
     expect(umStack.length).toBe(3);
-    expect(keys(all).length).toBe(initComps);
+    expect(keys(all).length).toBe(DEFAULT_CMPS);
   });
 });

--- a/test/specs/pages/index.ts
+++ b/test/specs/pages/index.ts
@@ -2,6 +2,7 @@ import { ComponentDefinition } from '../../../src/dom_components/model/types';
 import Editor from '../../../src/editor';
 import EditorModel from '../../../src/editor/model/Editor';
 import { PageProperties } from '../../../src/pages/model/Page';
+import { DEFAULT_CMPS } from '../../common';
 
 describe('Pages', () => {
   let editor: Editor;
@@ -50,7 +51,7 @@ describe('Pages', () => {
     const frameCmp = frame.getComponent();
     expect(frameCmp.components().length).toBe(0);
     expect(frame.getStyles().length).toBe(0);
-    expect(initCmpLen).toBe(1);
+    expect(initCmpLen).toBe(DEFAULT_CMPS);
   });
 
   test('Adding new page with selection', () => {
@@ -143,8 +144,8 @@ describe('Pages', () => {
         .filter(i => i.is('wrapper'));
       expect(wrappers.length).toBe(initPages.length);
       // Components container should contain the right amount of components
-      // Number of wrappers (eg. 3) where each one containes 1 component and 1 textnode (3 * 3)
-      expect(initCmpLen).toBe(initPages.length * 3);
+      // Number of wrappers (eg. 3) where each one containes 1 component and 1 textnode (5 * 3)
+      expect(initCmpLen).toBe((2 + DEFAULT_CMPS) * 3);
       // Each page contains 1 rule per component
       expect(em.Css.getAll().length).toBe(initPages.length);
     });

--- a/test/specs/parser/model/ParserHtml.ts
+++ b/test/specs/parser/model/ParserHtml.ts
@@ -535,7 +535,6 @@ describe('ParserHtml', () => {
     const result = [
       {
         tagName: 'div',
-        attributes: {},
         type: 'text',
         test: {
           prop1: 'value1',
@@ -553,7 +552,6 @@ describe('ParserHtml', () => {
     const result = [
       {
         tagName: 'div',
-        attributes: {},
         type: 'text',
         test: ['value1', 'value2'],
         components: { type: 'textnode', content: 'test2 ' },
@@ -655,7 +653,7 @@ describe('ParserHtml', () => {
       expect(obj.parse(str, null, { preParser }).html).toEqual([result]);
     });
 
-    test.only('parsing as document', () => {
+    test('parsing as document', () => {
       const str = `
         <!DOCTYPE html>
         <html class="cls-html" lang="en" data-gjs-htmlp="true">
@@ -672,13 +670,13 @@ describe('ParserHtml', () => {
           </body>
         </html>
       `;
-      // asDocument: true
-      console.log(obj.parse(str, null, { asDocument: true }));
+
       expect(obj.parse(str, null, { asDocument: true })).toEqual({
         doctype: '<!DOCTYPE html>',
         root: { classes: ['cls-html'], attributes: { lang: 'en' }, htmlp: true },
         head: {
           type: 'head',
+          tagName: 'head',
           headp: true,
           classes: ['cls-head'],
           components: [

--- a/test/specs/parser/model/ParserHtml.ts
+++ b/test/specs/parser/model/ParserHtml.ts
@@ -654,5 +654,69 @@ describe('ParserHtml', () => {
       const preParser = (str: string) => str.replace('javascript:', 'test:');
       expect(obj.parse(str, null, { preParser }).html).toEqual([result]);
     });
+
+    test.only('parsing as document', () => {
+      const str = `
+        <!DOCTYPE html>
+        <html class="cls-html" lang="en" data-gjs-htmlp="true">
+          <head class="cls-head" data-gjs-headp="true">
+            <meta charset="utf-8">
+            <title>Test</title>
+            <link rel="stylesheet" href="/noop.css">
+            <!-- comment -->
+            <script src="/noop.js"></script>
+            <style>.test { color: red }</style>
+          </head>
+          <body class="cls-body" data-gjs-bodyp="true">
+            <h1>H1</h1>
+          </body>
+        </html>
+      `;
+      // asDocument: true
+      console.log(obj.parse(str, null, { asDocument: true }));
+      expect(obj.parse(str, null, { asDocument: true })).toEqual({
+        doctype: '<!DOCTYPE html>',
+        root: { classes: ['cls-html'], attributes: { lang: 'en' }, htmlp: true },
+        head: {
+          type: 'head',
+          headp: true,
+          classes: ['cls-head'],
+          components: [
+            { tagName: 'meta', attributes: { charset: 'utf-8' } },
+            {
+              tagName: 'title',
+              type: 'text',
+              components: { type: 'textnode', content: 'Test' },
+            },
+            {
+              tagName: 'link',
+              attributes: { rel: 'stylesheet', href: '/noop.css' },
+            },
+            {
+              type: 'comment',
+              tagName: '',
+              content: ' comment ',
+            },
+            {
+              tagName: 'style',
+              type: 'text',
+              components: { type: 'textnode', content: '.test { color: red }' },
+            },
+          ],
+        },
+        html: {
+          tagName: 'body',
+          bodyp: true,
+          classes: ['cls-body'],
+          components: [
+            {
+              tagName: 'h1',
+              type: 'text',
+              components: { type: 'textnode', content: 'H1' },
+            },
+          ],
+        },
+      });
+    });
   });
 });

--- a/test/specs/parser/model/ParserHtml.ts
+++ b/test/specs/parser/model/ParserHtml.ts
@@ -15,7 +15,7 @@ describe('ParserHtml', () => {
       textTypes: ['text', 'textnode', 'comment'],
       returnArray: true,
     });
-    obj.compTypes = dom.componentTypes as any;
+    obj.compTypes = dom.componentTypes;
   });
 
   test('Simple div node', () => {


### PR DESCRIPTION
This PR introduces a new feature that allows importing the HTML string as documents. 
More details about the current problem and the implemented solution.

## Problem
Currently, the editor imports only the content inside the body, so if you try to import this content inside the main wrapper...
```js
editor.getWrapper().components(`
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Doc title</title>
  </head>
  <body>
    <h1>Body title</h1>
  </body>
</html>
`);
```
... and try to get its HTML content (eg. via `editor.getHtml()`), this is what you get
```js
<body>
  <meta charset="utf-8"/>
  <title>Doc title</title>
  <h1>Body title</h1>
</body>
```
All the HTML document information is lost (eg. doctype, head, etc.), and some elements (eg. inside the `head`) are moved inside the body.
This was intentional as the editor's main purpose was always to manage only the content of the pages but this is not always suitable for all use cases.

## Solution
To support the document import, the HTML parser and the wrapper component were extended to handle those data.
In order to avoid possible breaking changes, a new option `asDocument` is required.
```js
editor.getWrapper().components(`
<!DOCTYPE html>
 ...
</html>
`, { asDocument: true });
```
Now the document information will be preserved if you try to get its HTML.

## Additional API
The HTML document data are stored inside the wrapper component.
```js
const wrapper = editor.getWrapper();
const { 
  head, // ComponentHead
  docEl,  // Component
  doctype, // string
} = wrapper;

head.toHTML(); // `<head ...</head>`
docEl.toHTML(); // '<html></html>' // no children here
doctype; //  '<!DOCTYPE html>'
```

## Caveats

* The `asDocument` option is only valid if used on the wrapper component.
* In case you're making use of the `config.canvas.styles`/`config.canvas.scripts` options, those will be replaced with the content of the imported document. 
