### PR TITLE
Add an option to return inline style even if we want to avoid it at the beginning

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -5,7 +5,7 @@ interface NOOP {}
 
 export type Debounced = Function & { cancel(): void };
 
-export type SetOptions = Backbone.ModelSetOptions & { avoidStore?: boolean };
+export type SetOptions = Backbone.ModelSetOptions & { avoidStore?: boolean; inline?: boolean };
 
 export type AddOptions = Backbone.AddOptions & { temporary?: boolean };
 

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -671,9 +671,9 @@ export default class Component extends StyleableModel<ComponentProperties> {
 
     // Add style
     if (!opts.noStyle) {
-      const style = this.get('style');
+      const style = this.getStyle();
       if (isObject(style) && !isEmptyObj(style)) {
-        attributes.style = this.styleToString({ inline: 1 });
+        attributes.style = this.styleToString();
       }
     }
 
@@ -1572,7 +1572,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
     const tag = customTag || model.get('tagName');
     const sTag = model.get('void');
     const customAttr = opts.attributes;
-    let attributes = this.getAttrToHTML();
+    let attributes = this.getAttrToHTML(opts);
     delete opts.tag;
 
     // Get custom attributes if requested
@@ -1643,10 +1643,10 @@ export default class Component extends StyleableModel<ComponentProperties> {
    * @return {Object}
    * @private
    */
-  getAttrToHTML() {
+  getAttrToHTML(opts?: ToHTMLOptions) {
     const attrs = this.getAttributes();
 
-    if (avoidInline(this.em)) {
+    if (avoidInline(this.em) && opts?.keepInlineStyle !== true) {
       delete attrs.style;
     }
 

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -613,6 +613,10 @@ export default class Component extends StyleableModel<ComponentProperties> {
       if (rule) {
         return rule.getStyle(prop);
       }
+
+      // Return empty style if not rule have been found. We cannot return inline style with the next return
+      // because else on load inline style is set a #id or .class style
+      return {};
     }
 
     return super.getStyle.call(this, prop);

--- a/src/dom_components/model/Component.ts
+++ b/src/dom_components/model/Component.ts
@@ -540,7 +540,7 @@ export default class Component extends StyleableModel<ComponentProperties> {
 
     // Handle style
     const style = attrs.style;
-    style && this.setStyle(style);
+    style && this.setStyle(style, opts);
     delete attrs.style;
 
     const attrPrev = { ...this.previous('attributes') };
@@ -671,9 +671,9 @@ export default class Component extends StyleableModel<ComponentProperties> {
 
     // Add style
     if (!opts.noStyle) {
-      const style = this.getStyle();
+      const style = this.getStyle({ inline: true });
       if (isObject(style) && !isEmptyObj(style)) {
-        attributes.style = this.styleToString();
+        attributes.style = this.styleToString({ inline: true });
       }
     }
 

--- a/src/dom_components/model/types.ts
+++ b/src/dom_components/model/types.ts
@@ -281,6 +281,11 @@ export type ToHTMLOptions = {
   altQuoteAttr?: boolean;
 
   /**
+   * Keep inline style set intentionally by users with `setStyle({}, { inline: true })`
+   */
+  keepInlineStyle?: boolean;
+
+  /**
    * You can pass an object of custom attributes to replace with the current ones
    * or you can even pass a function to generate attributes dynamically.
    */

--- a/src/editor/config/config.ts
+++ b/src/editor/config/config.ts
@@ -7,6 +7,7 @@ import { DeviceManagerConfig } from '../../device_manager/config/config';
 import { I18nConfig } from '../../i18n/config';
 import { ModalConfig } from '../../modal_dialog/config/config';
 import { LayerManagerConfig } from '../../navigator/config/config';
+import { KeymapsConfig } from '../../keymaps/config';
 import { PageManagerConfig } from '../../pages/types';
 import { PanelsConfig } from '../../panels/config/config';
 import { ParserConfig } from '../../parser/config/config';
@@ -355,6 +356,11 @@ export interface EditorConfig {
    * Configurations for Commands.
    */
   commands?: CommandsConfig;
+
+  /**
+   * Configurations for keymaps
+   */
+  keymaps?: KeymapsConfig;
 
   /**
    * Configurations for Css Composer.

--- a/test/specs/dom_components/model/Component.ts
+++ b/test/specs/dom_components/model/Component.ts
@@ -280,11 +280,11 @@ describe('Component', () => {
       class: 'class1 class2',
       style: 'color: white; background: #fff',
     });
+    // Style is not in attributes because it has not been set as inline
     expect(obj.getAttributes()).toEqual({
       id: 'test',
       class: 'class1 class2',
       'data-test': 'value',
-      style: 'color:white;background:#fff;',
     });
     expect(obj.classes.length).toEqual(2);
     expect(obj.getStyle()).toEqual({
@@ -298,12 +298,21 @@ describe('Component', () => {
     expect(obj.getStyle()).toEqual(CSS_BG_OBJ);
   });
 
+  test('set style on id and inline style', () => {
+    obj.setStyle({ color: 'red' }); // Should be set on id
+    obj.setStyle({ display: 'flex' }, { inline: true }); // Should be set as inline
+
+    expect(obj.getStyle()).toEqual({
+      color: 'red',
+    });
+    expect(obj.getStyle({ inline: true })).toEqual({
+      display: 'flex',
+    });
+  });
+
   test('get proper style from style with multiple values of the same key', () => {
-    obj.setAttributes({ style: CSS_BG_STR });
-    const attrToCheck = obj.getAttributes();
-    expect(attrToCheck.id).toBeDefined();
-    delete attrToCheck.id;
-    expect(attrToCheck).toEqual({
+    obj.setAttributes({ style: CSS_BG_STR }, { inline: true });
+    expect(obj.getAttributes()).toEqual({
       style: CSS_BG_STR.split('\n').join(''),
     });
   });

--- a/test/specs/dom_components/model/Component.ts
+++ b/test/specs/dom_components/model/Component.ts
@@ -19,7 +19,9 @@ let em: Editor;
 
 describe('Component', () => {
   beforeEach(() => {
-    em = new Editor({ avoidDefaults: true });
+    // FIXME: avoidInlineStyle is deprecated and when running in dev or prod, `avoidInlineStyle` is set to true
+    // The following tests ran with `avoidInlineStyle` to false (this is why I add the parameter here)
+    em = new Editor({ avoidDefaults: true, avoidInlineStyle: true });
     dcomp = em.Components;
     em.Pages.onLoad();
     compOpts = {
@@ -281,8 +283,8 @@ describe('Component', () => {
     expect(obj.getAttributes()).toEqual({
       id: 'test',
       class: 'class1 class2',
-      style: 'color:white;background:#fff;',
       'data-test': 'value',
+      style: 'color:white;background:#fff;',
     });
     expect(obj.classes.length).toEqual(2);
     expect(obj.getStyle()).toEqual({
@@ -291,14 +293,17 @@ describe('Component', () => {
     });
   });
 
-  test('set inline style with multiple values of the same key', () => {
+  test('set style with multiple values of the same key', () => {
     obj.setAttributes({ style: CSS_BG_STR });
     expect(obj.getStyle()).toEqual(CSS_BG_OBJ);
   });
 
-  test('get proper style from inline style with multiple values of the same key', () => {
+  test('get proper style from style with multiple values of the same key', () => {
     obj.setAttributes({ style: CSS_BG_STR });
-    expect(obj.getAttributes()).toEqual({
+    const attrToCheck = obj.getAttributes();
+    expect(attrToCheck.id).toBeDefined();
+    delete attrToCheck.id;
+    expect(attrToCheck).toEqual({
       style: CSS_BG_STR.split('\n').join(''),
     });
   });


### PR DESCRIPTION
Hi 👋

Here is the context why I'm creating this PR. I saw that the config parameter `avoidInlineStyle` is now deprecated because of responsive and state management. But in some case we could still need inline style.

For example, if you get a dynamic list with multiple elements and each element has a specific color that you want to use as text color. You can only do it with inline style. But if here we set inline style, this is because you want it and you know you will cannot handle responsive and state on the text color.

### `avoidInlineStyle = true`

If I understand correctly, `avoidInlineStyle` is set to true by default to handle responsive and state management. We can still add inline style with `setStyle('color: red;', { inline: true })` but when we get the final HTML with `toHTML()`, the inline style is remove and style is lost.

<img width="704" alt="Screenshot 2024-06-08 at 09 32 25" src="https://github.com/GrapesJS/grapesjs/assets/18048363/0c8d6cd6-9230-4a56-9307-411148a6aa6a">

### `avoidInlineStyle = false`

When we put `avoidInlineStyle` to false, and we do `setStyle('color: red;', { inline: true })`, the inline style is set correctly but at the CSS generation (`editor.getCss()`), the same style is also added in the CSS code. What we don't want because we explicitly specify `{ inline: true }` when setting the style.

<img width="896" alt="Screenshot 2024-06-08 at 09 29 59" src="https://github.com/GrapesJS/grapesjs/assets/18048363/919739e9-d602-4955-9de3-d47421dfd9dd">

### What do I change?

So I just add one export parameter in `ToHTMLOptions` named `keepInlineStyle` to allow inline style when it is explicitly wanted.

By doing that, I saw that the test suite `Component` was running an editor with `avoidInlineStyle` set to false, which is not the default way of working now if I understand. So I set it to true in the test suite and fix 3 tests that work a little but differently.

### To conclude

```js
// Set style on #id or .class
cmp.setStyle({ color: 'red' })
// OR
cmp.setAttributes({ style: 'color: red' })

// Style has not been set as an attributes but as a CSS rule
console.log(cmp.getAttributes()) // {}
console.log(cmp.getStyle()) // { color: 'red' }


// Set style on #id or .class
cmp.setStyle({ color: 'red' },  { inline: true })
// OR
cmp.setAttributes({ style: 'color: red' }, { inline: true })

// Style has not been set as an attributes but as a CSS rule
console.log(cmp.getAttributes()) // { style: 'color: red;' }
console.log(cmp.getStyle()) // {}
console.log(cmp.getStyle({ inline: true })) // { color: 'red' }
```

I hope my PR is clear and you will understand why I did this.

PS: Something totally different, I add the `keymaps` config key in the editor config type to avoid typescript check issue when using it.

Do not hesitate if you have any reviews or comments!