### PR TITLE
fix: detach reused components from their old collection in `resetFromString`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grapesjs",
   "description": "Free and Open Source Web Builder Framework",
-  "version": "0.23.1-rc.0",
+  "version": "0.23.1",
   "author": "Artur Arseniev",
   "license": "BSD-3-Clause",
   "homepage": "http://grapesjs.com",

--- a/packages/core/src/dom_components/model/Components.ts
+++ b/packages/core/src/dom_components/model/Components.ts
@@ -70,6 +70,8 @@ const getComponentsFromDefs = (
           result = all[id] as any;
           const { onAttributes, onStyle } = updateOptions;
           const component = result as unknown as Component;
+          // Detach the reused model from its old container so re-inserting it updates `collection`/`parent`
+          component.collection?.remove(component, { silent: true } as any);
           const htmlImportOpts = { ...opts, parsedImportSource: 'html' as const };
           tagName && component.set({ tagName }, { ...htmlImportOpts, silent: true });
 

--- a/packages/core/test/specs/dom_components/model/Component.ts
+++ b/packages/core/test/specs/dom_components/model/Component.ts
@@ -582,6 +582,31 @@ describe('Component', () => {
     );
   });
 
+  test('resetFromString re-parents a reused component when its wrapper is removed', () => {
+    const wrapper = dcomp.getWrapper()!;
+    wrapper.components().resetFromString(`<div id="i5y6"><p id="i8sd">Insert your text here</p></div>`);
+
+    const div = wrapper.components().at(0);
+    const paragraph = div.components().at(0);
+    expect(div.getId()).toBe('i5y6');
+    expect(paragraph.getId()).toBe('i8sd');
+    expect(paragraph.parent()).toBe(div);
+
+    // Remove the wrapping div, promoting the reused <p> to a direct child of the wrapper.
+    wrapper.components().resetFromString(`<p id="i8sd">Insert your text here</p>`);
+
+    const allById = dcomp.allById();
+    // The same <p> model instance is reused, not rebuilt.
+    expect(wrapper.components().at(0)).toBe(paragraph);
+    expect(allById['i8sd']).toBe(paragraph);
+    // The removed div is gone from the global registry.
+    expect(allById['i5y6']).toBeUndefined();
+    // The reused <p> reports the wrapper as its parent, not the removed div.
+    expect(paragraph.parent()).toBe(wrapper);
+    expect(paragraph.collection).toBe(wrapper.components());
+    expect(em.getHtml()).toBe('<body><p id="i8sd">Insert your text here</p></body>');
+  });
+
   test('Ability to stop/change propagation chain', () => {
     obj.append({
       removable: false,


### PR DESCRIPTION
### Problem

`resetFromString` reuses existing component models by `id` (via `getComponentsFromDefs`) rather than rebuilding them. When a reused model lands under a new parent, it gets added to the new collection but never removed from the old one. Backbone only lets a model belong to one collection, so the move half-happens:

- `model.collection` is never reassigned, so `parent()` still points at the old parent.
- the old parent's collection still holds the model, so removing that old parent recurses into and tears down a node that's actually still in the tree.

### Repro

Wrapper contains:

```html
<div id="i5y6"><p id="i8sd">Insert your text here</p></div>
```

Delete the `<div>` so it resets to just `<p id="i8sd">…</p>`. The `<p>` is correctly reused and moved up to the body, but `p.parent()` still returns the deleted `<div>`. Anything that walks up the tree from there (RTE re-parenting, layers, sorter) ends up on a dead node.

### Fix

Detach the reused model from its current container before re-inserting it, the same way `Component.append()` already does when moving a model:

```ts
component.collection?.remove(component, { silent: true } as any);
```

It has to be `silent` - a normal remove fires `remove` on the old collection, which gets forwarded to symbol instances and deletes the wrong thing. The silent remove just clears the old reference; the following `reset` handles rendering and symbol sync as usual.

### Tests

Added a regression test in `Component.ts` for the case above (reused `<p>` is the same instance, stays in `componentsById`, old `<div>` is gone, and `parent()`/`collection` point at the wrapper). Fails on `main`, passes with the fix.
