### PR TITLE
fix(asset-manager): enforce accept filter on drag-and-dropped files

### DIFF
--- a/packages/core/src/asset_manager/view/FileUploader.ts
+++ b/packages/core/src/asset_manager/view/FileUploader.ts
@@ -6,6 +6,26 @@ import html from '../../utils/html';
 import { AssetManagerConfig } from '../config/config';
 import { UploadFileClb, UploadFileOptions } from '../types';
 
+/**
+ * Check if a file matches an `accept` attribute value.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept
+ * Allows everything when empty or a bare wildcard; otherwise supports MIME
+ * wildcards (`image/*`), exact MIME (`image/png`), and extensions (`.png`).
+ */
+export function isFileAccepted(file: File, accept?: string | null): boolean {
+  const acc = (accept || '').trim();
+  if (!acc || acc === '*' || acc === '*/*') return true;
+  const type = (file.type || '').toLowerCase();
+  const name = (file.name || '').toLowerCase();
+  return acc.split(',').some((raw) => {
+    const token = raw.trim().toLowerCase();
+    if (!token) return false;
+    if (token.startsWith('.')) return name.endsWith(token); // extension
+    if (token.endsWith('/*')) return type.startsWith(token.slice(0, -1)); // e.g. "image/"
+    return type === token; // exact MIME
+  });
+}
+
 type FileUploaderTemplateProps = {
   pfx: string;
   title: string;
@@ -141,7 +161,14 @@ export default class FileUploaderView extends View {
    * */
   uploadFile(e: DragEvent, clb?: UploadFileClb, opts?: UploadFileOptions) {
     opts; // Options are not used here but can be used by the custom uploadFile function
-    const files = e.dataTransfer ? e.dataTransfer.files : ((e.target as any)?.files as FileList);
+    const allFiles = e.dataTransfer ? e.dataTransfer.files : ((e.target as any)?.files as FileList);
+    // #6032: the `accept` attribute is not enforced by browsers on drag-drop, so filter here.
+    const accept = this.$el.find('input[type=file]').attr('accept');
+    const files = Array.prototype.filter.call(allFiles || [], (f: File) => isFileAccepted(f, accept)) as File[];
+
+    // All dropped files rejected (e.g. a video on an image upload) -> do nothing.
+    if (allFiles && allFiles.length && !files.length) return;
+
     const { config } = this;
     const { beforeUpload } = config;
 

--- a/packages/core/test/specs/asset_manager/view/FileUploader.ts
+++ b/packages/core/test/specs/asset_manager/view/FileUploader.ts
@@ -1,4 +1,26 @@
-import FileUploader from '../../../../src/asset_manager/view/FileUploader';
+import FileUploader, { isFileAccepted } from '../../../../src/asset_manager/view/FileUploader';
+
+const f = (type: string, name = 'x') => ({ type, name }) as File;
+
+describe('isFileAccepted (#6032)', () => {
+  test('allows everything when accept is empty or */*', () => {
+    expect(isFileAccepted(f('video/mp4', 'a.mp4'), '')).toBe(true);
+    expect(isFileAccepted(f('video/mp4', 'a.mp4'), '*/*')).toBe(true);
+    expect(isFileAccepted(f('video/mp4', 'a.mp4'), undefined)).toBe(true);
+  });
+  test('matches MIME wildcard (image/*)', () => {
+    expect(isFileAccepted(f('image/png', 'a.png'), 'image/*')).toBe(true);
+    expect(isFileAccepted(f('video/mp4', 'a.mp4'), 'image/*')).toBe(false);
+  });
+  test('matches exact MIME and comma lists', () => {
+    expect(isFileAccepted(f('image/png'), 'image/png,image/jpeg')).toBe(true);
+    expect(isFileAccepted(f('image/gif'), 'image/png,image/jpeg')).toBe(false);
+  });
+  test('matches file extensions', () => {
+    expect(isFileAccepted(f('', 'photo.PNG'), '.png')).toBe(true);
+    expect(isFileAccepted(f('', 'clip.mp4'), '.png,.jpg')).toBe(false);
+  });
+});
 
 describe('File Uploader', () => {
   let obj: FileUploader;
@@ -70,6 +92,33 @@ describe('File Uploader', () => {
       view.render();
       expect(view.$el.find('input[type=file]').prop('disabled')).toEqual(false);
       expect(view.uploadFile).toEqual(FileUploader.embedAsBase64);
+    });
+  });
+
+  describe('Drag-drop respects accept (#6032)', () => {
+    const makeView = () => {
+      const customFetch = jest.fn(() => Promise.resolve('[]'));
+      // headers:{} is REQUIRED: direct construction does NOT merge the module's config
+      // defaults, and uploadFile reads `config.headers` before fetching - a missing
+      // headers object throws before customFetch is ever reached.
+      const view = new FileUploader({ config: { upload: 'http://localhost/up', headers: {}, customFetch } });
+      document.body.innerHTML = '<div id="fx"></div>';
+      document.body.querySelector('#fx')!.appendChild(view.render().el);
+      view.$el.find('input[type=file]').attr('accept', 'image/*'); // what OpenAssets sets for images
+      return { view, customFetch };
+    };
+    const drop = (view: FileUploader, file: File) =>
+      view.uploadFile({ dataTransfer: { files: [file] }, preventDefault() {} } as any);
+
+    test('rejects a dropped video (no upload triggered)', () => {
+      const { view, customFetch } = makeView();
+      drop(view, new File(['x'], 'clip.mp4', { type: 'video/mp4' }));
+      expect(customFetch).not.toHaveBeenCalled();
+    });
+    test('still uploads a dropped image', () => {
+      const { view, customFetch } = makeView();
+      drop(view, new File(['x'], 'pic.png', { type: 'image/png' }));
+      expect(customFetch).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
Fixes #6032

## Problem
Dropping a non-image file (e.g. a video) onto an image component's asset upload zone uploads it and lets you select it as the image `src`. Reported as drag-drop-only.

## Root cause
`OpenAssets` sets `accept="image/*"` on the upload input, which filters the native file picker — but browsers do NOT enforce `accept` on drag-and-dropped files. `FileUploader.uploadFile()` reads `e.dataTransfer.files` and uploads them with no validation.

## Fix
Filter incoming files in `uploadFile()` against the input's `accept` value via a small pure helper (`isFileAccepted`), and bail out before uploading if none match. Backward-compatible: with no/`*/*` accept (generic asset managers), nothing is filtered. Custom `uploadFile` implementations are unaffected.

## Tests
Unit tests for `isFileAccepted` (MIME wildcard / exact / extension / `*/*`) and an integration test asserting a dropped video does not trigger an upload while a dropped image does.

## Live demo
Side-by-side StackBlitz (double-click the image to open the Asset Manager, then drop a video vs an image):
- Fixed: https://stackblitz.com/github/geonsang-jo/grapesjs-core-demos/tree/6032-image-video-accept?file=src/main.ts&startScript=dev&view=preview
- Before fix (bug repro): https://stackblitz.com/github/geonsang-jo/grapesjs-core-demos/tree/6032-as-is?file=src/main.ts&startScript=dev&view=preview

## Notes on behavior
- The rejection is silent, consistent with the existing `beforeUpload` -> `false` cancel path (which also returns without emitting an event) and with the native `accept` picker (which silently omits non-matching files).
- `beforeUpload(files)` now receives the filtered `File[]` instead of the raw `FileList` (type `(files: any) => void | false`, so type-compatible). Also, when every dropped file is rejected, `beforeUpload` is not invoked at all (the early return precedes it).

## Questions for maintainers
1. **Rejected-file feedback:** the AM has no "rejected/invalid" event today, and the existing block hook (`beforeUpload` -> false) is silent, so this PR keeps rejection silent. If you'd prefer consumers be able to react (e.g. show "only image files allowed"), I'm happy to add an opt-in event following the `asset:upload:*` convention, e.g. `asset:upload:rejected` with `{ files, accept }`.
2. **Stale `accept` on the singleton uploader:** `OpenAssets.run()` only sets `accept` when truthy and never resets it, and the uploader input is a singleton rendered once (`AssetManager.render()` builds `AssetsView` only on first open). So after an image picker sets `accept="image/*"`, a later generic `AssetManager.open()` with no `accept` inherits the stale `image/*` — before this PR that only affected the native picker, now it also makes drag-drop silently filter non-image files there. I can reset it on each open (`uploadEl.setAttribute('accept', accept || '*/*')`) here or as a follow-up.
