### PR TITLE
docs: update DataSources examples to dataResolver format

### DIFF
--- a/docs/modules/DataSources.md
+++ b/docs/modules/DataSources.md
@@ -52,8 +52,10 @@ editor.addComponents([
     components: [
       {
         type: 'data-variable',
-        defaultValue: 'default',
-        path: 'my-datasource.id1.content',
+        dataResolver: {
+          defaultValue: 'default',
+          path: 'my-datasource.id1.content',
+        },
       },
     ],
   },
@@ -76,8 +78,10 @@ editor.addComponents([
     components: [
       {
         type: 'data-variable',
-        defaultValue: 'default',
-        path: 'my-datasource.id1.content',
+        dataResolver: {
+          defaultValue: 'default',
+          path: 'my-datasource.id1.content',
+        },
       },
     ],
     style: {
@@ -261,8 +265,10 @@ editor.addComponents([
     components: [
       {
         type: 'data-variable',
-        defaultValue: 'default',
-        path: 'my-datasource.id1.counter',
+        dataResolver: {
+          defaultValue: 'default',
+          path: 'my-datasource.id1.counter',
+        },
       },
     ],
   },


### PR DESCRIPTION
The DataSources docs still show the pre-https://github.com/GrapesJS/grapesjs/pull/6495 flat shape for component-level
`data-variable` (`defaultValue`/`path` as top-level props). Since https://github.com/GrapesJS/grapesjs/pull/6495 those
props live in the `dataResolver` object, and the old shape fails silently —
nothing renders and record updates are ignored (see the linked issue, where a
user copied the docs' counter example verbatim).

- Updated the 3 component examples (components, styles section, counter) to the
  `dataResolver` shape, matching `test/specs/data_sources/model/ComponentDataVariable.ts`.
- Style and trait data variables still use the flat shape (per
  `test/specs/data_sources/dynamic_values/styles.ts` / `traits.ts`), so those
  examples are unchanged.