### PR TITLE
fix(parser): don't drop @container/@layer at-rules on CSS parse (#5969)

### DIFF
--- a/packages/core/src/parser/model/BrowserParserCss.ts
+++ b/packages/core/src/parser/model/BrowserParserCss.ts
@@ -215,7 +215,7 @@ export const parseNode = (el: CSSStyleSheet | CSSRule) => {
       singleAtRule = true;
       atRuleType = AT_RULE_NAMES[type];
       condition = parseCondition(node);
-    } else if (AT_RULE_KEYS.indexOf(`${type}`) >= 0 || (!type && getNestableAtRule(node))) {
+    } else if (AT_RULE_KEYS.indexOf(`${type}`) >= 0 || getNestableAtRule(node)) {
       const subRules = parseNode(node);
       const subAtRuleType = AT_RULE_NAMES[type] || getNestableAtRule(node);
       condition = parseCondition(node);

--- a/packages/core/test/specs/css_composer/model/CssModels.ts
+++ b/packages/core/test/specs/css_composer/model/CssModels.ts
@@ -97,6 +97,16 @@ describe('CssRule', () => {
     expect(obj.toCSS()).toEqual(`@media ${media}{.test1{color:red;}}`);
   });
 
+  test('toCSS keeps the space in a named container rule', () => {
+    const containerText = 'somename (min-width: 300px)';
+    obj.set('atRuleType', 'container');
+    obj.set('mediaText', containerText);
+    obj.getSelectors().add({ name: 'test1' });
+    obj.setStyle({ height: '100px' });
+    expect(obj.getAtRule()).toEqual(`@container ${containerText}`);
+    expect(obj.toCSS()).toEqual(`@container ${containerText}{.test1{height:100px;}}`);
+  });
+
   test('toCSS with a generic at-rule', () => {
     obj.set('atRuleType', 'supports');
     obj.getSelectors().add({ name: 'test1' });

--- a/packages/core/test/specs/parser/model/ParserCss.ts
+++ b/packages/core/test/specs/parser/model/ParserCss.ts
@@ -375,8 +375,7 @@ describe('ParserCss', () => {
     expect(obj.parse(str)).toEqual([result]);
   });
 
-  // Unsupported by CSSOM parser
-  test.skip('Parse rule with @container at-rule', () => {
+  test('Parse rule with @container at-rule', () => {
     const atRuleType = 'container';
     const atRuleText = 'somename (min-width: 300px)';
     const input = `@${atRuleType} ${atRuleText} {
@@ -386,17 +385,32 @@ describe('ParserCss', () => {
     const output = [
       {
         selectors: ['cls1'],
-        selectorsAdd: '',
         atRuleType,
         mediaText: atRuleText,
         style: { height: '100px' },
       },
       {
         selectors: ['cls2'],
-        selectorsAdd: '',
         atRuleType,
         mediaText: atRuleText,
         style: { height: '200px' },
+      },
+    ];
+    expect(obj.parse(input)).toEqual(output);
+  });
+
+  test('Parse rule with anonymous @container at-rule', () => {
+    const atRuleType = 'container';
+    const atRuleText = '(min-width: 300px)';
+    const input = `@${atRuleType} ${atRuleText} {
+      .cls1{ height: 100px }
+    }`;
+    const output = [
+      {
+        selectors: ['cls1'],
+        atRuleType,
+        mediaText: atRuleText,
+        style: { height: '100px' },
       },
     ];
     expect(obj.parse(input)).toEqual(output);


### PR DESCRIPTION
### Problem

Closes #5969. `@container` (and other nestable at-rules like `@layer`) are silently dropped by the CSS parser on engines that expose a real numeric `CSSRule.type`.

`parseNode` in `BrowserParserCss` only entered the nestable-at-rule branch when the legacy `type` was falsy: `(!type && getNestableAtRule(node))`. Chrome reports `type === 0` for these newer rules so it happened to work there, but any engine that returns a numeric type (jsdom returns `17` for `CSSContainerRule`) fell through every branch and the entire rule — selectors, styles and condition — was discarded. When the rule survived at all, this is what produced the reported invalid export `@container portable(max-width: 639px)` with the missing space.

### Solution

Detect nestable at-rules with `getNestableAtRule(node)` regardless of the numeric `type`. `getNestableAtRule` only matches when the rule's `cssText` starts with the exact `@<name>`, so normal style/keyframe rules are untouched. The parsed condition keeps the container name and query separated by a space, so the exported CSS is valid again: `@container somename (min-width: 300px){...}`.

### Tests

- Un-skipped and corrected the pre-existing `Parse rule with @container at-rule` spec (its output no longer includes `selectorsAdd: ''`, matching the `@media` specs). It fails before this change (the rule is dropped) and passes after.
- Added an anonymous `@container` parse spec and a `toCSS` spec asserting the space is preserved on export.
- Full parser / css_composer / code_manager / dom_components / selector_manager / style_manager suites pass with no regressions (792 passing).

### Disclosure

Prepared with assistance from Claude (AI); the change and tests were reviewed and verified locally by the author (`pnpm test`, `eslint`, `prettier --check` all clean).
