### PR TITLE
fix(video): support both YouTube and Vimeo mute parameters

### DIFF
--- a/packages/core/src/dom_components/model/ComponentVideo.ts
+++ b/packages/core/src/dom_components/model/ComponentVideo.ts
@@ -131,7 +131,8 @@ export default class ComponentVideo extends ComponentImage {
         parseInt(qr.controls) === 0 && this.set('controls', false);
         hasParam(qr.color) && this.set('color', qr.color);
         qr.rel === '0' && this.set('rel', 0);
-        qr.muted === '1' && this.set('muted', true);
+        // YouTube uses "mute" param, Vimeo uses "muted"
+        (qr.mute === '1' || qr.muted === '1') && this.set('muted', true);
         break;
       default:
     }


### PR DESCRIPTION
- Add support for YouTube's "mute" parameter in video component query parsing
- Maintain backward compatibility with Vimeo's "muted" parameter
- Update condition to check for either qr.mute or qr.muted before setting muted state
- Add clarifying comment explaining parameter difference between platforms