### PR TITLE
fix: drag&drop issues when the editor is in a shadowRoot

### DIFF
--- a/packages/core/src/utils/sorter/DropLocationDeterminer.ts
+++ b/packages/core/src/utils/sorter/DropLocationDeterminer.ts
@@ -4,7 +4,7 @@ import EditorModel from '../../editor/model/Editor';
 import { isTextNode, off, on } from '../dom';
 import { SortableTreeNode } from './SortableTreeNode';
 import { Placement, PositionOptions, DragDirection, SorterEventHandlers, CustomTarget, DragSource } from './types';
-import { bindAll, each } from 'underscore';
+import { bindAll, each, isFunction } from 'underscore';
 import { matches, findPosition, offset, isStyleInFlow } from './SorterUtils';
 import { RateLimiter } from './RateLimiter';
 import Dimension from './Dimension';
@@ -287,9 +287,24 @@ export class DropLocationDeterminer<T, NodeType extends SortableTreeNode<T>> ext
     return newHoveredNode;
   }
 
+  /**
+   * Resolves the root to run the hit-test against.
+   *
+   * `Document.elementFromPoint` doesn't pierce shadow boundaries, so when the container lives
+   * inside a shadow root it would always return the host element instead of the hovered item.
+   * `ShadowRoot` implements the same `DocumentOrShadowRoot` mixin and resolves within its own tree.
+   */
+  private getContainerContextRoot(): DocumentOrShadowRoot {
+    const root = this.containerContext.container?.getRootNode() as Partial<DocumentOrShadowRoot> | undefined;
+    if (isFunction(root?.elementFromPoint)) {
+      return root as DocumentOrShadowRoot;
+    }
+    return this.containerContext.document;
+  }
+
   private getMouseTargetElement(mouseEvent: MouseEvent) {
     const customTarget = this.containerContext.customTarget;
-    let mouseTarget = this.containerContext.document.elementFromPoint(
+    let mouseTarget = this.getContainerContextRoot().elementFromPoint(
       mouseEvent.clientX,
       mouseEvent.clientY,
     ) as HTMLElement;

--- a/packages/core/src/utils/sorter/Sorter.ts
+++ b/packages/core/src/utils/sorter/Sorter.ts
@@ -173,7 +173,7 @@ export default class Sorter<T, NodeType extends SortableTreeNode<T>> {
   private ensurePlaceholderElement() {
     const el = this.placeholder.el;
     const container = this.containerContext.container;
-    if (!el.ownerDocument.contains(el)) {
+    if (!el.isConnected) {
       container.append(this.placeholder.el);
     }
   }


### PR DESCRIPTION
Basic implementation of the fix for https://github.com/GrapesJS/grapesjs/issues/6823

It contains two fixes for the case when the editor is loaded in a shadowRoot (in a webcomponent) : 
- Sorter#ensurePlaceholderElement > use `el.isConnected` instead of `el.ownerDocument.contains`
- Fix DropLocationDeterminer because `Document.elementFromPoint` does not pierce shadow boundaries

It compiles successfully and it resolves the issue I had. However I am not 100% that the fix is correct. Please let me know if you want me to improve it our change something