### PR TITLE
fix: keep modals open when dragging over backdrop

### DIFF
--- a/packages/core/src/modal_dialog/view/ModalView.ts
+++ b/packages/core/src/modal_dialog/view/ModalView.ts
@@ -19,9 +19,13 @@ export default class ModalView extends ModuleView<Modal> {
   events() {
     return {
       click: 'onClick',
+      mousedown: 'onMouseDown',
+      mouseup: 'onMouseUp',
       'click [data-close-modal]': 'hide',
     };
   }
+
+  private ignoreBackdropClick = false;
 
   $title?: JQuery<HTMLElement>;
   $content?: JQuery<HTMLElement>;
@@ -35,9 +39,18 @@ export default class ModalView extends ModuleView<Modal> {
     this.listenTo(model, 'change:content', this.updateContent);
   }
 
+  onMouseDown(e: Event) {
+    this.ignoreBackdropClick = e.target !== this.el;
+  }
+
+  onMouseUp(e: Event) {
+    this.ignoreBackdropClick = this.ignoreBackdropClick || e.target !== this.el;
+  }
+
   onClick(e: Event) {
-    const bkd = this.config.backdrop;
-    bkd && e.target === this.el && this.hide();
+    const isBackdropClick = e.target === this.el && !this.ignoreBackdropClick;
+    this.ignoreBackdropClick = false;
+    this.config.backdrop && isBackdropClick && this.hide();
   }
 
   /**

--- a/packages/core/test/specs/modal/view/ModalView.js
+++ b/packages/core/test/specs/modal/view/ModalView.js
@@ -9,7 +9,7 @@ describe('ModalView', () => {
 
   beforeEach(() => {
     em = new Editor({});
-    model = new Modal(em);
+    model = new Modal(em.Modal);
     view = new ModalView({
       model,
     });
@@ -52,5 +52,47 @@ describe('ModalView', () => {
   test('Open dialog', () => {
     model.set('open', 1);
     expect(view.el.style.display).toEqual('');
+  });
+
+  const clickBetween = (start, end) => {
+    start.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    end.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    view.el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  };
+
+  test('Closes on a complete backdrop click', () => {
+    model.open();
+    clickBetween(view.el, view.el);
+    expect(model.get('open')).toBeFalsy();
+  });
+
+  test('Does not close when dragging from the dialog to the backdrop', () => {
+    model.open();
+    clickBetween(view.getContent().get(0), view.el);
+    expect(model.get('open')).toBeTruthy();
+    clickBetween(view.el, view.el);
+    expect(model.get('open')).toBeFalsy();
+  });
+
+  test('Does not close when dragging from the backdrop into the dialog', () => {
+    model.open();
+    clickBetween(view.el, view.getContent().get(0));
+    expect(model.get('open')).toBeTruthy();
+  });
+
+  test('Respects the disabled backdrop setting', () => {
+    view.config.backdrop = false;
+    model.open();
+    clickBetween(view.el, view.el);
+    expect(model.get('open')).toBeTruthy();
+  });
+
+  test('The close button still closes after interacting with the dialog', () => {
+    model.open();
+    const close = view.el.querySelector('[data-close-modal]');
+    close.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    close.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    close.click();
+    expect(model.get('open')).toBeFalsy();
   });
 });


### PR DESCRIPTION
Fixes #6683.

A press inside the dialog followed by a release on the backdrop can generate a click targeted at the modal container, closing the editor while the user is dragging or selecting text. Track whether the press or release occurred inside the dialog and ignore the resulting backdrop click. Reset the gesture state after the click so the next complete backdrop click still closes normally.

The reverse gesture (backdrop to dialog) also stays open. The close button and `backdrop: false` behavior are preserved.

Validation:

- Added five modal-view tests. The fixture now passes `em.Modal` to the modal model, matching the production module/configuration; the old fixture passed the whole editor and had no backdrop setting.
- On the original source, both drag-direction tests fail while normal backdrop and close-button controls pass.
- Full core suite passes: 1,532 tests and 17 snapshots; 47 existing tests skipped across one skipped suite.
- CLI build, core JS/ESM/CSS/declaration builds, declaration type check, changed-file ESLint, Prettier, and `git diff --check` pass.
- Chromium loaded the locally built editor and CSS, opened a modal with a textarea, and reproduced the original failure using native mouse input. After the fix, drags in both directions stay open; normal backdrop mouse clicks and touch taps respect the backdrop option; the close button closes. Checked with `backdrop` both true and false, without page errors.

Tested on Windows with Node 24.19 and pnpm 9.10.0. The browser fixture uses the real `editor.Modal.open()` path; the external custom-code plugin from the issue was not installed. Generated build artifacts and dependencies are excluded.

AI assistance: OpenAI Codex was used for investigation, implementation, and validation.
