### PR TITLE
fix: give canvas iframe a localized accessible name

### DIFF
--- a/packages/core/src/canvas/view/FrameView.ts
+++ b/packages/core/src/canvas/view/FrameView.ts
@@ -21,7 +21,7 @@ export default class FrameView extends ModuleView<Frame, HTMLIFrameElement> {
   }
   /** @ts-ignore */
   get attributes() {
-    return { allowfullscreen: 'allowfullscreen' };
+    return { allowfullscreen: 'allowfullscreen', title: this.em.t('canvas.frameTitle') };
   }
 
   dragging = false;

--- a/packages/core/src/i18n/locale/en.js
+++ b/packages/core/src/i18n/locale/en.js
@@ -17,6 +17,9 @@ export default {
       // 'category-id': 'Category Label',
     },
   },
+  canvas: {
+    frameTitle: 'Editor canvas',
+  },
   domComponents: {
     names: {
       '': 'Box',

--- a/packages/core/test/specs/canvas/FrameView.ts
+++ b/packages/core/test/specs/canvas/FrameView.ts
@@ -1,0 +1,37 @@
+import Frame from '../../../src/canvas/model/Frame';
+import FrameView from '../../../src/canvas/view/FrameView';
+import EditorModel from '../../../src/editor/model/Editor';
+
+describe('Canvas frame accessible name', () => {
+  let em: EditorModel;
+
+  afterEach(() => {
+    em.destroy();
+  });
+
+  const createFrame = () => new FrameView(new Frame(em.Canvas, {}));
+
+  test('names the editor iframe by default', () => {
+    em = new EditorModel({});
+    const view = createFrame();
+    expect(view.el.tagName).toBe('IFRAME');
+    expect(view.el.title).toBe('Editor canvas');
+    expect(view.el.hasAttribute('allowfullscreen')).toBe(true);
+  });
+
+  test('uses the configured translation', () => {
+    em = new EditorModel({
+      i18n: {
+        locale: 'fr',
+        detectLocale: false,
+        messagesAdd: { fr: { canvas: { frameTitle: 'Zone de contenu' } } },
+      },
+    });
+    expect(createFrame().el.title).toBe('Zone de contenu');
+  });
+
+  test('falls back to English when the locale has no frame title', () => {
+    em = new EditorModel({ i18n: { locale: 'fr', detectLocale: false } });
+    expect(createFrame().el.title).toBe('Editor canvas');
+  });
+});


### PR DESCRIPTION
The editor canvas iframe has no accessible name, making its purpose unclear when navigating frames with a screen reader. Add a `title` from the existing i18n system, with the default English value `Editor canvas` and a customizable `canvas.frameTitle` message. Other locales use the configured fallback. The title is set when the frame view is created, alongside its existing fullscreen attribute.

Closes #6668.

Validation:
- All three new regression cases fail on the original code and pass with the change: default name, custom translation, and fallback locale.
- Full core suite: 1,530 tests and 17 snapshots pass; 47 existing tests skipped.
- Core production build (JS, ESM, CSS, declarations), declaration type check, changed-file ESLint/Prettier, and `git diff --check` pass.
- Chromium running the built editor reproduces the original unnamed iframe. With the fix, Playwright's accessible-name assertion passes for all three configurations, and the iframe's editable content renders without page errors.

Validation used Node 24.19.0 and pnpm 9.10.0. I have not tested NVDA or JAWS; confirmation with the reporter's screen-reader setup would be helpful. This change was prepared with AI assistance and checked against the source, regression tests, and built editor.
