### PR TITLE
fix: cancel pending style manager updates on destroy

### DIFF
--- a/packages/core/src/style_manager/index.ts
+++ b/packages/core/src/style_manager/index.ts
@@ -79,6 +79,8 @@ export default class StyleManager extends ItemManagerModule<
 > {
   builtIn: PropertyFactory;
   upAll: Debounced;
+  private upProps: Debounced & (() => void);
+  private trgCustom: Debounced & (() => void);
   properties: typeof Properties;
   events = StyleManagerEvents;
   sectors: Sectors;
@@ -121,15 +123,15 @@ export default class StyleManager extends ItemManagerModule<
     model.listenTo(em, ComponentsEvents.toggled, this.__clearStateTarget);
 
     // Triggers only for properties (avoid selection refresh)
-    const upProps = debounce(() => {
+    this.upProps = debounce(() => {
       this.__upProps();
       this.__trgCustom();
     }, 0);
-    model.listenTo(em, 'styleable:change undo redo', upProps);
+    model.listenTo(em, 'styleable:change undo redo', this.upProps);
 
     // Triggers only custom event
-    const trgCustom = debounce(() => this.__trgCustom(), 0);
-    model.listenTo(em, `${events.layerSelect} ${events.target}`, trgCustom);
+    this.trgCustom = debounce(() => this.__trgCustom(), 0);
+    model.listenTo(em, `${events.layerSelect} ${events.target}`, this.trgCustom);
 
     // Other listeners
     model.on('change:lastTarget', () => em.trigger(events.target, this.getSelected()));
@@ -836,5 +838,7 @@ export default class StyleManager extends ItemManagerModule<
     this.SectView?.remove();
     this.model.stopListening();
     this.upAll.cancel();
+    this.upProps.cancel();
+    this.trgCustom.cancel();
   }
 }

--- a/packages/core/test/specs/style_manager/destroy.ts
+++ b/packages/core/test/specs/style_manager/destroy.ts
@@ -1,0 +1,52 @@
+import Editor from '../../../src/editor';
+
+describe('StyleManager pending updates on destroy', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('does not refresh properties after destroying the editor', () => {
+    const editor = new Editor({});
+    const em = editor.getModel();
+    em.Pages.onLoad();
+    const component = editor.addComponents({ type: 'text', content: 'Text', style: { padding: '5px' } })[0];
+    em.Styles.select(component);
+    jest.runOnlyPendingTimers();
+    const update = jest.spyOn(em.Styles, '__upProps');
+    component.setStyle({ padding: '10px' });
+    editor.destroy();
+    expect(() => jest.runOnlyPendingTimers()).not.toThrow();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test('does not send pending custom events after destroying the module', () => {
+    const editor = new Editor({});
+    const em = editor.getModel();
+    const styles = em.Styles;
+    const custom = jest.fn();
+    em.on(styles.events.custom, custom);
+    em.trigger(styles.events.target, undefined);
+    styles.destroy();
+    jest.runOnlyPendingTimers();
+    expect(custom).not.toHaveBeenCalled();
+    editor.destroy();
+  });
+
+  test('still refreshes properties and sends custom events while alive', () => {
+    const editor = new Editor({});
+    const em = editor.getModel();
+    const update = jest.spyOn(em.Styles, '__upProps');
+    const custom = jest.fn();
+    em.on(em.Styles.events.custom, custom);
+    em.trigger('styleable:change');
+    jest.runOnlyPendingTimers();
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(custom).toHaveBeenCalled();
+    editor.destroy();
+  });
+});


### PR DESCRIPTION
Style Manager cancels its debounced selection refresh during destruction, but leaves two other callbacks queued: property updates and custom events. A style change followed immediately by editor destruction still invokes the property updater; a target change followed by module destruction still emits a custom event.

Retain both debounced functions and cancel them alongside `upAll` after stopping listeners. This keeps deferred work from running after teardown without changing live update behavior.

Related to #6494. I investigated the rapid create/destroy report but could not reproduce its original exception on the current build; this PR addresses the confirmed incomplete cleanup and intentionally does not close that issue.

Validation:
- Two regression cases fail on the original source and pass with the fix: pending property updates after editor destruction (with an actual styled selection) and custom events after module destruction. A live-update control passes in both versions.
- Full core suite: 1,530 tests and 17 snapshots pass; 47 existing tests skipped. The strengthened selection setup was also rerun in the focused suite.
- Core production build (JS, ESM, CSS and declarations), declaration type check, changed-file ESLint/Prettier, and diff checks pass.
- Chromium running the built editor completes ten create/select/style/destroy cycles without page errors. Instrumented methods forward to the originals and confirm no property/custom callbacks execute after destruction.

Prepared with AI assistance and validated locally using Node 24.19.0 and pnpm 9.10.0. No dependency, lockfile, or public API changes.
